### PR TITLE
Fix wrong property name on FlaisApplicationSpec: `deploymentStragegy`  should be `stragegy`

### DIFF
--- a/src/main/kotlin/no/fintlabs/operator/application/DeploymentDR.kt
+++ b/src/main/kotlin/no/fintlabs/operator/application/DeploymentDR.kt
@@ -25,6 +25,7 @@ class DeploymentDR : CRUDKubernetesDependentResource<Deployment, FlaisApplicatio
                 metadata = cretePodMetadata(primary)
                 spec = createPodSpec(primary, context)
             }
+            strategy = primary.spec.strategy
         }
     }
 

--- a/src/main/kotlin/no/fintlabs/operator/application/api/FlaisApplicationSpec.kt
+++ b/src/main/kotlin/no/fintlabs/operator/application/api/FlaisApplicationSpec.kt
@@ -42,7 +42,7 @@ data class FlaisApplicationSpec(
         message = "Invalid restartPolicy, must be one of Always, OnFailure, Never")
     val restartPolicy: String = "Always",
 
-    val deploymentStrategy: DeploymentStrategy? = null,
+    val strategy: DeploymentStrategy? = null,
     val prometheus: Prometheus = Prometheus(),
     val onePassword: OnePassword? = null,
     val kafka: Kafka = Kafka(),

--- a/src/test/unit/kotlin/no.fintlabs.operator.application/FlaisApplicationCrdTest.kt
+++ b/src/test/unit/kotlin/no.fintlabs.operator.application/FlaisApplicationCrdTest.kt
@@ -72,7 +72,7 @@ class FlaisApplicationCrdTest {
         assertThat(origFlaisApplication.spec.resources.limits, isEqualTo(resFlaisApplication.spec.resources.limits))
         assertThat(origFlaisApplication.spec.resources.requests, isEqualTo(resFlaisApplication.spec.resources.requests))
 
-        assertThat(origFlaisApplication.spec.deploymentStrategy, isEqualTo(resFlaisApplication.spec.deploymentStrategy))
+        assertThat(origFlaisApplication.spec.strategy, isEqualTo(resFlaisApplication.spec.strategy))
         assertThat(origFlaisApplication.spec.prometheus, isEqualTo(resFlaisApplication.spec.prometheus))
         assertThat(origFlaisApplication.spec.onePassword, isEqualTo(resFlaisApplication.spec.onePassword))
         assertThat(origFlaisApplication.spec.kafka, isEqualTo(resFlaisApplication.spec.kafka))
@@ -84,7 +84,7 @@ class FlaisApplicationCrdTest {
     @Test
     fun `FlaisApplicationCrd should have correct deploymentStrategy`() {
         val origFlaisApplication = createAndApplyFlaisApplication(
-            FlaisApplicationSpec(deploymentStrategy = DeploymentStrategy().apply {
+            FlaisApplicationSpec(strategy = DeploymentStrategy().apply {
                 type = "Recreate"
                 rollingUpdate = RollingUpdateDeployment().apply {
                     maxSurge = IntOrString("25%")
@@ -94,7 +94,7 @@ class FlaisApplicationCrdTest {
             )
         )
         val resFlaisApplication = getFlaisApplication()
-        assertThat(origFlaisApplication.spec.deploymentStrategy, isEqualTo(resFlaisApplication.spec.deploymentStrategy))
+        assertThat(origFlaisApplication.spec.strategy, isEqualTo(resFlaisApplication.spec.strategy))
     }
 
     @Test


### PR DESCRIPTION
Renamed `deploymentStrategy` back to `strategy`
Fixed strategy not set for deployment