### PR TITLE
Support structured logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ val operatorSdkVersion: String by project
 val awaitilityVersion: String by project
 val hopliteVersion: String by project
 val logbackVersion: String by project
+val logbackLogstashEncoderVersion: String by project
 
 
 plugins {
@@ -53,6 +54,8 @@ dependencies {
     implementation("com.sksamuel.hoplite:hoplite-core:$hopliteVersion")
     implementation("com.sksamuel.hoplite:hoplite-yaml:$hopliteVersion")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
+    implementation("net.logstash.logback:logstash-logback-encoder:$logbackLogstashEncoderVersion")
+
 
 
     testImplementation(kotlin("test"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ operatorSdkVersion=4.9.1
 awaitilityVersion=4.2.1
 hopliteVersion=2.7.5
 logbackVersion=1.5.6
+logbackLogstashEncoderVersion=7.4

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,26 @@
+<configuration>
+    <conversionRule conversionWord="msg" converterClass="no.nav.etterlatte.libs.common.person.FnrCoverConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>version</version>
+                <level>level</level>
+                <thread>thread</thread>
+                <logger>class</logger>
+                <message>message</message>
+                <context>context</context>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
+    </root>
+</configuration>

--- a/src/test/integration/resources/logback.xml
+++ b/src/test/integration/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/src/test/unit/resources/logback.xml
+++ b/src/test/unit/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Logging format can be set to json or "normal". Default is json.