### PR TITLE
Update replica minimum from 1 to 0

### DIFF
--- a/src/main/kotlin/no/fintlabs/operator/application/api/FlaisApplicationSpec.kt
+++ b/src/main/kotlin/no/fintlabs/operator/application/api/FlaisApplicationSpec.kt
@@ -10,7 +10,7 @@ data class FlaisApplicationSpec(
     @Required
     val orgId: String = "",
 
-    @Min(1.0)
+    @Min(0.0)
     val replicas: Int = 1,
 
     @Required


### PR DESCRIPTION
Some teams need to be able to set deployment replica to 0. 