### PR TITLE
Integration tests interfere during execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,8 @@ testing {
             targets {
                 all {
                     testTask.configure {
+                        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+                        forkEvery = 1
                         shouldRunAfter(test)
                     }
                 }

--- a/src/main/kotlin/no/fintlabs/Application.kt
+++ b/src/main/kotlin/no/fintlabs/Application.kt
@@ -32,11 +32,18 @@ val baseModule = module {
         }
     }
     single {
-        KubernetesClientBuilder().withKubernetesSerialization(KubernetesSerialization(get(), true)).build()
+        KubernetesClientBuilder()
+            .withKubernetesSerialization(KubernetesSerialization(get(), true))
+            .build()
+    }
+    single<(Operator) -> Unit> {
+        { operator ->
+            getAll<Reconciler<*>>().forEach { operator.register(it) }
+        }
     }
     single {
         Operator(ConfigurationService.newOverriddenConfigurationService { it.withKubernetesClient(get()) }).apply {
-            getAll<Reconciler<*>>().forEach { register(it) }
+            get<(Operator) -> Unit>().invoke(this)
         }
     }
 }


### PR DESCRIPTION
Namespaces are not getting cleaned up properly  between tests. Instead of waiting for cleanup to finish, which takes long, we reconfigure controllers to only listen to the current test namespace.