### PR TITLE
FLA-510 Migrate to Standalone Workflow for Enhanced Customization and Improved Error Handling

### DIFF
--- a/src/main/kotlin/no/fintlabs/operator/ApplicationReconcilerModule.kt
+++ b/src/main/kotlin/no/fintlabs/operator/ApplicationReconcilerModule.kt
@@ -1,8 +1,21 @@
 package no.fintlabs.operator
 
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 fun applicationReconcilerModule() = module {
-    single<Reconciler<*>> { no.fintlabs.operator.FlaisApplicationReconciler() }
+    single<Reconciler<*>>(named("flais-application-reconciler")) { FlaisApplicationReconciler() }
+    single { DeploymentDR() }
+    single { ServiceDR() }
+    single { PodMetricsDR() }
+    single { OnePasswordDR() }
+    single { IngressDR() }
+    single { PostgresUserDR() }
+    single { KafkaDR() }
+    single { CreatePodMetricsCondition() }
+    single { CreateOnePasswordCondition() }
+    single { CreateIngressCondition() }
+    single { CreatePostgresUserCondition() }
+    single { CreateKafkaCondition() }
 }

--- a/src/main/kotlin/no/fintlabs/operator/FlaisApplicationReconciler.kt
+++ b/src/main/kotlin/no/fintlabs/operator/FlaisApplicationReconciler.kt
@@ -1,98 +1,101 @@
 package no.fintlabs.operator
 
 import io.javaoperatorsdk.operator.api.reconciler.*
-import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow
+import io.javaoperatorsdk.operator.processing.dependent.workflow.WorkflowBuilder
+import io.javaoperatorsdk.operator.processing.dependent.workflow.WorkflowReconcileResult
+import io.javaoperatorsdk.operator.processing.event.source.EventSource
 import no.fintlabs.operator.api.DEPLOYMENT_CORRELATION_ID_ANNOTATION
 import no.fintlabs.operator.api.ORG_ID_LABEL
 import no.fintlabs.operator.api.TEAM_LABEL
 import no.fintlabs.operator.api.v1alpha1.FlaisApplicationCrd
 import no.fintlabs.operator.api.v1alpha1.FlaisApplicationState
 import no.fintlabs.operator.api.v1alpha1.FlaisApplicationStatus
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import org.koin.core.component.inject
 import org.slf4j.MDC
 import java.util.*
-import kotlin.jvm.optionals.getOrDefault
 
 
 @ControllerConfiguration(
-    dependents = [
-        Dependent(
-            name = DeploymentDR.COMPONENT,
-            type = DeploymentDR::class
-        ),
-        Dependent(
-            name = ServiceDR.COMPONENT,
-            type = ServiceDR::class
-        ),
-        Dependent(
-            name = PodMetricsDR.COMPONENT,
-            type = PodMetricsDR::class,
-            reconcilePrecondition = CreatePodMetricsCondition::class
-        ),
-        Dependent(
-            name = OnePasswordDR.COMPONENT,
-            type = OnePasswordDR::class,
-            reconcilePrecondition = CreateOnePasswordCondition::class
-        ),
-        Dependent(
-            name = IngressDR.COMPONENT,
-            type = IngressDR::class,
-            reconcilePrecondition = CreateIngressCondition::class
-        ),
-        Dependent(
-            name = PostgresUserDR.COMPONENT,
-            type = PostgresUserDR::class,
-            reconcilePrecondition = CreatePostgresUserCondition::class
-        ),
-        Dependent(
-            name = KafkaDR.COMPONENT,
-            type = KafkaDR::class,
-            reconcilePrecondition = CreateKafkaCondition::class
-        )
-    ],
     labelSelector = "$ORG_ID_LABEL,$TEAM_LABEL"
 )
-class FlaisApplicationReconciler : Reconciler<FlaisApplicationCrd>, Cleaner<FlaisApplicationCrd>, ContextInitializer<FlaisApplicationCrd> {
+class FlaisApplicationReconciler : Reconciler<FlaisApplicationCrd>, Cleaner<FlaisApplicationCrd>, EventSourceInitializer<FlaisApplicationCrd>, KoinComponent {
     private val logger = getLogger()
+
+    private val deployment by inject<DeploymentDR>()
+    private val service by inject<ServiceDR>()
+    private val podMetrics by inject<PodMetricsDR>()
+    private val onePassword by inject<OnePasswordDR>()
+    private val ingress by inject<IngressDR>()
+    private val postgresUser by inject<PostgresUserDR>()
+    private val kafka by inject<KafkaDR>()
+
+    private val workflow: Workflow<FlaisApplicationCrd> = WorkflowBuilder<FlaisApplicationCrd>()
+        .addDependentResource(deployment, DeploymentDR.COMPONENT)
+        .addDependentResource(service, ServiceDR.COMPONENT)
+        .addDependentResource(podMetrics, PodMetricsDR.COMPONENT)
+            .withReconcilePrecondition(get<CreatePodMetricsCondition>())
+        .addDependentResource(onePassword, OnePasswordDR.COMPONENT)
+            .withReconcilePrecondition(get<CreateOnePasswordCondition>())
+        .addDependentResource(ingress, IngressDR.COMPONENT)
+            .withReconcilePrecondition(get<CreateIngressCondition>())
+        .addDependentResource(postgresUser, PostgresUserDR.COMPONENT)
+            .withReconcilePrecondition(get<CreatePostgresUserCondition>())
+        .addDependentResource(kafka, KafkaDR.COMPONENT)
+            .withReconcilePrecondition(get<CreateKafkaCondition>())
+        .withThrowExceptionFurther(false)
+        .build()
 
     override fun reconcile(resource: FlaisApplicationCrd, context: Context<FlaisApplicationCrd>): UpdateControl<FlaisApplicationCrd> {
         setMDC(resource)
-        logger.info("Reconciling FlaisApplication ${resource.metadata.name}")
-        val updateControl = determineUpdateControl(resource, updateStatus(resource, context), updateResource(context))
-        removeMDC()
-        return updateControl
-    }
+        initReconciliation(resource)?.let {
+            removeMDC()
+            return it
+        }
 
-    private fun determineUpdateControl(resource: FlaisApplicationCrd, statusUpdated: Boolean, resourceUpdated: Boolean) = when {
-        statusUpdated && resourceUpdated -> UpdateControl.updateResourceAndStatus(resource)
-        resourceUpdated -> UpdateControl.updateResource(resource)
-        statusUpdated -> UpdateControl.updateStatus(resource)
-        else -> UpdateControl.noUpdate()
+        val result = workflow.reconcile(resource, context)
+        val statusUpdated = updateStatus(resource, determineNewStatus(resource, result))
+
+        return when {
+            statusUpdated -> UpdateControl.patchStatus(resource)
+            else -> UpdateControl.noUpdate()
+        }.also {
+            removeMDC()
+        }
     }
 
     override fun cleanup(resource: FlaisApplicationCrd, context: Context<FlaisApplicationCrd>): DeleteControl {
         return DeleteControl.defaultDelete()
     }
 
-    override fun initContext(primary: FlaisApplicationCrd, context: Context<FlaisApplicationCrd>) {
-        ensureCorrelationId(primary, context)
+    override fun prepareEventSources(context: EventSourceContext<FlaisApplicationCrd>): MutableMap<String, EventSource> =
+        EventSourceInitializer.eventSourcesFromWorkflow(context, workflow)
+
+    private fun initReconciliation(resource: FlaisApplicationCrd) : UpdateControl<FlaisApplicationCrd>? {
+        val annotations = resource.metadata.annotations
+        val hasCorrelationId = annotations.containsKey(DEPLOYMENT_CORRELATION_ID_ANNOTATION)
+        if (!hasCorrelationId) {
+            val uuid = UUID.randomUUID().toString()
+            logger.debug("Generating correlation ID $uuid for ${resource.metadata.name}")
+            annotations[DEPLOYMENT_CORRELATION_ID_ANNOTATION] = uuid
+        }
+
+        val newStatus = resource.status.copy(
+            state = FlaisApplicationState.PENDING,
+            correlationId = annotations[DEPLOYMENT_CORRELATION_ID_ANNOTATION]
+        )
+        val statusUpdated = updateStatus(resource, newStatus)
+
+        return when {
+            !hasCorrelationId -> UpdateControl.updateResourceAndStatus(resource)
+            statusUpdated -> UpdateControl.updateStatus(resource)
+            else -> null
+        }?.rescheduleAfter(0)
     }
 
-    private fun updateResource(context: Context<FlaisApplicationCrd>): Boolean {
-        return context.managedDependentResourceContext()
-            .get(DEPLOYMENT_CORRELATION_ID_GENERATED, Boolean::class.javaObjectType)
-            .getOrDefault(false)
-    }
-
-    private fun updateStatus(primary: FlaisApplicationCrd, context: Context<FlaisApplicationCrd>): Boolean {
-        val newStatus = determineNewStatus(primary, context)
-        return if (primary.status != newStatus) {
-            primary.status = newStatus
-            true
-        } else false
-    }
-
-    private fun determineNewStatus(primary: FlaisApplicationCrd, context: Context<FlaisApplicationCrd>): FlaisApplicationStatus {
-        val workflowResult = context.managedDependentResourceContext().workflowReconcileResult.get()
+    private fun determineNewStatus(primary: FlaisApplicationCrd, workflowResult: WorkflowReconcileResult): FlaisApplicationStatus {
         val ready = workflowResult.allDependentResourcesReady()
         val failed = workflowResult.erroredDependentsExist()
 
@@ -110,13 +113,11 @@ class FlaisApplicationReconciler : Reconciler<FlaisApplicationCrd>, Cleaner<Flai
         )
     }
 
-    private fun ensureCorrelationId(primary: FlaisApplicationCrd, context: Context<FlaisApplicationCrd>) {
-        primary.metadata.annotations.computeIfAbsent(DEPLOYMENT_CORRELATION_ID_ANNOTATION) {
-            val uuid = UUID.randomUUID().toString()
-            logger.debug("Generating correlation ID $uuid for ${primary.metadata.name}")
-            context.managedDependentResourceContext().put(DEPLOYMENT_CORRELATION_ID_GENERATED, true)
-            uuid
-        }
+    private fun updateStatus(primary: FlaisApplicationCrd, newStatus: FlaisApplicationStatus): Boolean {
+        return if (primary.status != newStatus) {
+            primary.status = newStatus
+            true
+        } else false
     }
 
     private fun setMDC(resource: FlaisApplicationCrd) {

--- a/src/main/kotlin/no/fintlabs/operator/FlaisApplicationReconciler.kt
+++ b/src/main/kotlin/no/fintlabs/operator/FlaisApplicationReconciler.kt
@@ -5,6 +5,7 @@ import io.javaoperatorsdk.operator.processing.dependent.workflow.Workflow
 import io.javaoperatorsdk.operator.processing.dependent.workflow.WorkflowBuilder
 import io.javaoperatorsdk.operator.processing.dependent.workflow.WorkflowReconcileResult
 import io.javaoperatorsdk.operator.processing.event.source.EventSource
+import io.javaoperatorsdk.operator.processing.retry.GradualRetry
 import no.fintlabs.operator.api.DEPLOYMENT_CORRELATION_ID_ANNOTATION
 import no.fintlabs.operator.api.ORG_ID_LABEL
 import no.fintlabs.operator.api.TEAM_LABEL
@@ -19,6 +20,7 @@ import java.util.*
 import kotlin.jvm.optionals.getOrNull
 
 
+@GradualRetry(maxAttempts = 3)
 @ControllerConfiguration(
     labelSelector = "$ORG_ID_LABEL,$TEAM_LABEL"
 )

--- a/src/main/kotlin/no/fintlabs/operator/api/v1alpha1/FlaisApplicationStatus.kt
+++ b/src/main/kotlin/no/fintlabs/operator/api/v1alpha1/FlaisApplicationStatus.kt
@@ -5,5 +5,6 @@ import io.javaoperatorsdk.operator.api.ObservedGenerationAwareStatus
 data class FlaisApplicationStatus(
     val state: FlaisApplicationState = FlaisApplicationState.PENDING,
     val correlationId: String? = null,
-    val dependentResourceStatus: List<String> = emptyList()
+    val dependentResourceStatus: List<String> = emptyList(),
+    val dependentErrors: Map<String, String>? = null
 ) : ObservedGenerationAwareStatus()

--- a/src/test/integration/kotlin/no/fintlabs/operator/FlaisApplicationReconcilerTest.kt
+++ b/src/test/integration/kotlin/no/fintlabs/operator/FlaisApplicationReconcilerTest.kt
@@ -1,0 +1,74 @@
+package no.fintlabs.operator
+
+import no.fintlabs.extensions.KubernetesOperatorContext
+import no.fintlabs.operator.Utils.createAndGetResource
+import no.fintlabs.operator.Utils.createKoinTestExtension
+import no.fintlabs.operator.Utils.createKubernetesOperatorExtension
+import no.fintlabs.operator.Utils.createTestFlaisApplication
+import no.fintlabs.operator.Utils.waitUntil
+import no.fintlabs.operator.api.v1alpha1.FlaisApplicationCrd
+import no.fintlabs.operator.api.v1alpha1.FlaisApplicationState
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.koin.core.component.inject
+import org.koin.test.KoinTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class FlaisApplicationReconcilerTest : KoinTest {
+
+    @Test
+    fun `should set correlation id on FlaisApplication`(context: KubernetesOperatorContext) {
+        val flaisApplication = createTestFlaisApplication()
+        val app = context.createAndGetApplication(flaisApplication)
+
+        assertNotNull(app)
+        assertContains(app.metadata.annotations, "fintlabs.no/deployment-correlation-id")
+        assertNotNull(app.status.correlationId)
+        assertEquals(app.metadata.annotations["fintlabs.no/deployment-correlation-id"], app.status.correlationId)
+    }
+
+    @Test
+    fun `should not set correlation id on FlaisApplication if exists`(context: KubernetesOperatorContext) {
+        val flaisApplication = createTestFlaisApplication().apply {
+            metadata.annotations["fintlabs.no/deployment-correlation-id"] = "123"
+        }
+        val app = context.createAndGetApplication(flaisApplication)
+
+        assertNotNull(app)
+        assertContains(app.metadata.annotations, "fintlabs.no/deployment-correlation-id")
+        assertEquals("123", app.metadata.annotations["fintlabs.no/deployment-correlation-id"])
+        assertNotNull(app.status.correlationId)
+        assertEquals("123", app.status.correlationId)
+    }
+
+    @Test
+    fun `should handle dependent errors`(context: KubernetesOperatorContext) {
+        val service: ServiceDR by inject()
+        service.setResourceDiscriminator { _, _, _ ->
+            throw RuntimeException("test")
+        }
+
+        val flaisApplication = createTestFlaisApplication()
+        context.create(flaisApplication)
+        context.waitUntil<FlaisApplicationCrd>(flaisApplication.metadata.name) { it.status.state != FlaisApplicationState.PENDING }
+        val app = context.get<FlaisApplicationCrd>(flaisApplication.metadata.name)
+
+        assertNotNull(app)
+        assertEquals(1, app.status.dependentErrors?.size)
+        assertEquals("test", app.status.dependentErrors?.get("Service"))
+    }
+
+
+    private fun KubernetesOperatorContext.createAndGetApplication(app: FlaisApplicationCrd) =
+        createAndGetResource<FlaisApplicationCrd>(app)
+
+    companion object {
+        @RegisterExtension
+        val koinTestExtension = createKoinTestExtension()
+
+        @RegisterExtension
+        val kubernetesOperatorExtension = createKubernetesOperatorExtension()
+    }
+}


### PR DESCRIPTION
### Key Changes:
1. **Standalone Workflow Implementation**:
   - Transitioned from the managed workflow to a standalone workflow to enable custom handling of dependent resources.
   - Initialise CRD status state to be PENDING before starting reconciliation and generate correlation id if necessary 

2. **Custom Error Handling**:
   - Added `ErrorStatusHandler` for custom error handling of failed dependent resources.
   - Updated `determineNewStatus` to properly handle and report `dependentErrors` for failed dependents.

3. **CRD Status Updates**:
   - Ensured that CRD status is updated accurately based on the reconciliation outcomes.
   - Delayed setting `FlaisApplicationState` to `FAILED` until the final reconciliation attempt has been reached, ensuring retry logic is respected.

4. **Retry Logic for Dependent Resources**:
   - Introduced `@GradualRetry(maxAttempts = 3)` on `FlaisApplicationReconciler` to limit retries and prevent infinite update loops when dependent resources fail to deploy.

### Fixes:
- **FLA-502**: Failing dependent resources are triggering infinite updates.
- **FLA-510**: CRD status not updated correctly when handling errored dependents.
