### PR TITLE
FLA-513 Fix pod monitors are not able to find targets

### DIFF
--- a/src/main/kotlin/no/fintlabs/operator/PodMetricsDR.kt
+++ b/src/main/kotlin/no/fintlabs/operator/PodMetricsDR.kt
@@ -16,13 +16,14 @@ import no.fintlabs.operator.api.v1alpha1.FlaisApplicationCrd
 class PodMetricsDR : CRUDKubernetesDependentResource<PodMonitor, FlaisApplicationCrd>(PodMonitor::class.java) {
     override fun desired(primary: FlaisApplicationCrd, context: Context<FlaisApplicationCrd>): PodMonitor = PodMonitor().apply {
         val metrics = primary.spec.observability?.metrics ?: primary.spec.prometheus
+        val portName = if (metrics.port.toInt() == primary.spec.port) "http" else "metrics"
 
         metadata = createObjectMeta(primary)
         spec = PodMonitorSpec().apply {
             jobLabel = "app.kubernetes.io/name"
             podTargetLabels = listOf("app", "fintlabs.no/team", "fintlabs.no/org-id")
             podMetricsEndpoints = listOf(PodMetricsEndpoints().apply {
-                port = metrics.port
+                port = portName
                 path = metrics.path
                 honorLabels = false
             })

--- a/src/test/integration/kotlin/no/fintlabs/operator/PodMetricsDRTest.kt
+++ b/src/test/integration/kotlin/no/fintlabs/operator/PodMetricsDRTest.kt
@@ -31,6 +31,8 @@ class PodMetricsDRTest {
         assertNotNull(podMonitor)
         assertEquals("test", podMonitor.metadata.name)
         assertEquals("test", podMonitor.spec.selector.matchLabels["app"])
+        assertEquals("/actuator/prometheus", podMonitor.spec.podMetricsEndpoints[0].path)
+        assertEquals("http", podMonitor.spec.podMetricsEndpoints[0].port)
     }
 
     @Test
@@ -46,7 +48,7 @@ class PodMetricsDRTest {
         val podMonitor = context.createAndGetPodMonitor(flaisApplication)
         assertNotNull(podMonitor)
         assertEquals("/metrics", podMonitor.spec.podMetricsEndpoints[0].path)
-        assertEquals("1234", podMonitor.spec.podMetricsEndpoints[0].port)
+        assertEquals("metrics", podMonitor.spec.podMetricsEndpoints[0].port)
     }
 
     @Test


### PR DESCRIPTION
- Updated PodMonitor spec to use port name ("http" or "metrics") based on observability metrics configuration.
- Update tests so that they match expected output