### PR TITLE
Fix Deployment Update and Application Patching Issues

### DIFF
--- a/src/main/kotlin/no/fintlabs/operator/DeploymentDR.kt
+++ b/src/main/kotlin/no/fintlabs/operator/DeploymentDR.kt
@@ -51,7 +51,7 @@ class DeploymentDR : CRUDKubernetesDependentResource<Deployment, FlaisApplicatio
         val actualSelector = kubernetesSerialization.convertValue(actual.spec.selector, Map::class.java)
         val podSelectorMatch = desiredSelector == actualSelector
 
-        if (podSelectorMatch) return handleUpdate(actual, desired, primary, context)
+        if (podSelectorMatch) return super.handleUpdate(actual, desired, primary, context)
 
         logger.info("Pod selector does not match, recreating deployment ${actual.metadata.name}")
         handleDelete(primary, actual, context)

--- a/src/main/kotlin/no/fintlabs/operator/FlaisApplicationReconciler.kt
+++ b/src/main/kotlin/no/fintlabs/operator/FlaisApplicationReconciler.kt
@@ -66,7 +66,7 @@ class FlaisApplicationReconciler : Reconciler<FlaisApplicationCrd>, Cleaner<Flai
         val statusUpdated = updateStatus(resource, determineNewStatus(resource, context, result))
 
         return when {
-            statusUpdated -> UpdateControl.patchStatus(resource)
+            statusUpdated -> UpdateControl.updateStatus(resource)
             else -> UpdateControl.noUpdate()
         }.also {
             removeMDC()

--- a/src/test/integration/kotlin/no/fintlabs/operator/DeploymentDRTest.kt
+++ b/src/test/integration/kotlin/no/fintlabs/operator/DeploymentDRTest.kt
@@ -122,6 +122,22 @@ class DeploymentDRTest {
         assertNotNull(deployment)
         assertEquals("Recreate", deployment.spec.strategy.type)
     }
+
+    @Test
+    fun `should update deployment with correct image`(context: KubernetesOperatorContext) {
+        val flaisApplication = createTestFlaisApplication().apply {
+            spec = spec.copy(image = "test-image:latest")
+        }
+
+        var deployment = context.createAndGetDeployment(flaisApplication)
+        assertNotNull(deployment)
+        assertEquals("test-image:latest", deployment.spec.template.spec.containers[0].image)
+
+        flaisApplication.spec = flaisApplication.spec.copy(image = "test-image:234567890")
+        deployment = context.updateAndGetResource(flaisApplication)
+        assertNotNull(deployment)
+        assertEquals("test-image:234567890", deployment.spec.template.spec.containers[0].image)
+    }
     //endregion
 
     //region Metadata


### PR DESCRIPTION
### Summary:
This PR addresses two key issues related to Deployment updates and status patching in `FlaisApplication`, and adds a test to ensure proper handling of Deployment updates.

### Changes:
- **Fix Deployment not updating:** A missing call to `super.handleUpdate` has been added to ensure that Deployments are correctly updated during the reconciliation process.
- **Fix Kubernetes patch exception:** Resolved an exception that occurred when patching the status of `FlaisApplication` by switching to the `updateStatus` method.
- **Add test for Deployment update:** A new unit test has been added to verify that the Deployment is correctly updated during reconciliation and that the correct update logic is followed.