### PR TITLE
Fix CodeQL error due to Gradle build cache 

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -47,7 +47,6 @@ jobs:
         with:
           patterns: |
             -**/*test*.kt
-            -**/generated-main-avro-java/**
           input: sarif-results/java.sarif
           output: sarif-results/java.sarif
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Assemble
-        run: ./gradlew assemble --parallel -Dorg.gradle.jvmargs="-Dkotlin.daemon.jvmargs=-Xmx8g" --configuration-cache
+        run: ./gradlew clean assemble --parallel --no-daemon --no-build-cache
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This pull request includes updates to the `jobs` section of the `.github/workflows/codeql.yaml` file to improve the build and analysis process. The most important changes include modifying the build command to clean and assemble without using the build cache, and removing a pattern from the analysis input.

Changes to build and analysis process:

* [`.github/workflows/codeql.yaml`](diffhunk://#diff-ec82a1210eee62532fa878b35c0defd6db76f03a97579afabe79a90588d72165L37-R37): Updated the `Assemble` step to run `./gradlew clean assemble --parallel --no-daemon --no-build-cache` instead of the previous command.
* [`.github/workflows/codeql.yaml`](diffhunk://#diff-ec82a1210eee62532fa878b35c0defd6db76f03a97579afabe79a90588d72165L50): Removed the `-**/generated-main-avro-java/**` pattern from the `patterns` section in the `Perform CodeQL Analysis` step.