### PR TITLE
Refactor: Centralize Gradle Configuration in Root build.gradle File

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,9 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 
 plugins {
     application
-
     kotlin("jvm")
     alias(libs.plugins.fabric8.generator)
 }
@@ -26,6 +27,7 @@ repositories {
 }
 
 dependencies {
+    implementation(kotlin("stdlib"))
     implementation(platform(libs.koin.bom))
     implementation(libs.koin.core)
     implementation(libs.bundles.fabric8)
@@ -84,6 +86,23 @@ testing {
 }
 
 tasks {
+    withType<Wrapper> {
+        gradleVersion = "8.12"
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
+    withType<KotlinCompile> {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
+            freeCompilerArgs.add("-Xjsr305=strict")
+        }
+    }
+
     jar {
         archiveBaseName = "app"
         manifest {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,14 +1,7 @@
-
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    kotlin("jvm") version "2.1.0"
     `kotlin-dsl`
+    alias(libs.plugins.kotlin.jvm)
 }
-
-group = "no.fintlabs.fintlabs"
-version = "unspecified"
 
 repositories {
     gradlePluginPortal()
@@ -16,27 +9,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("gradle-plugin"))
-    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 
     implementation(libs.fabric8.generator.api)
     implementation(libs.fabric8.generator.collector)
-}
-
-tasks {
-    withType<Wrapper> {
-        gradleVersion = "8.12"
-    }
-
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
-        }
-    }
-
-    withType<KotlinCompile> {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_21
-            freeCompilerArgs.add("-Xjsr305=strict")
-        }
-    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ http4k = "5.45.1.0"
 micrometer = "1.14.3"
 
 [libraries]
-
 fabric8-kubernetes-client = { module = "io.fabric8:kubernetes-client", version.ref = "fabric8" }
 fabric8-generator-api = { module = "io.fabric8:crd-generator-api-v2", version.ref = "fabric8" }
 fabric8-generator-collector = { module = "io.fabric8:crd-generator-collector", version.ref = "fabric8" }
@@ -47,6 +46,7 @@ koin-test = { module = "io.insert-koin:koin-test" }
 koin-test-junit5 = { module = "io.insert-koin:koin-test-junit5" }
 
 [plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.1.0"}
 fabric8-generator = { id = "io.fabric8.java-generator", version.ref = "fabric8" }
 
 [bundles]


### PR DESCRIPTION
This pull request includes several updates to the build configuration files to streamline dependencies and plugin management. The most important changes involve replacing direct Kotlin JVM plugin versioning with a version alias, and updating the `gradle/libs.versions.toml` file to include the new plugin alias.

Build configuration updates:

* [`buildSrc/build.gradle.kts`](diffhunk://#diff-7b5c40eb5522b5216cfe8c75612e579a8db0daee9ded80df9ce6a56e8361a962L1-L42): Removed direct Kotlin JVM plugin versioning and replaced it with an alias for better dependency management. Additionally, removed unused imports and tasks to clean up the build script.

Dependency management updates:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR49): Added a new entry for the Kotlin JVM plugin with the specified version, allowing for centralized version management.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL16): Removed an unnecessary blank line in the libraries section to maintain consistency.