### PR TITLE
Optimize dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,11 +7,26 @@ updates:
       day: "sunday"
     open-pull-requests-limit: 10
     groups:
-      gradle:
+      kubernetes:
         patterns:
-          - '*'
-
+          - "io.fabric8*"
+          - "io.javaoperatorsdk*"
+      micrometer:
+        patterns:
+          - "io.micrometer*"
+      div:
+        patterns:
+          - "com.sksamuel.hoplite*"
+          - "com.fasterxml.jackson.module*"
           - "org.http4k*"
+          - "ch.qos.logback*"
+          - "net.logstash.logback*"
+          - "io.mockk*"
+          - "org.awaitility*"
+          - "io.github.netmikey.logunit*"
+          - "io.insert-koin*"
+          - "org.jetbrains.kotlin*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,9 @@
 version: 2
 updates:
-  # Gradle dependencies (weekly)
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 10
     groups:
@@ -12,22 +11,21 @@ updates:
         patterns:
           - '*'
 
-  # GitHub Actions dependencies (monthly)
+          - "org.http4k*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "sunday"
     groups:
       github-actions:
         patterns:
           - '*'
 
-  # Docker dependencies (monthly)
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "sunday"
     groups:
       docker:


### PR DESCRIPTION
* Changed the update interval for Gradle, GitHub Actions, and Docker dependencies from monthly to weekly.
* Divided Gradle deps into groups `kubernetes`, `micrometer` and `div`