### PR TITLE
Add Probes

### DIFF
--- a/charts/flaiserator-crd/charts/crds/templates/applications.fintlabs.no-v1.yml
+++ b/charts/flaiserator-crd/charts/crds/templates/applications.fintlabs.no-v1.yml
@@ -188,6 +188,63 @@ spec:
               port:
                 minimum: 1.0
                 type: "integer"
+              probes:
+                properties:
+                  liveness:
+                    properties:
+                      failureThreshold:
+                        type: "integer"
+                      initialDelaySeconds:
+                        type: "integer"
+                      path:
+                        type: "string"
+                      periodSeconds:
+                        type: "integer"
+                      port:
+                        anyOf:
+                        - type: "integer"
+                        - type: "string"
+                        x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        type: "integer"
+                    type: "object"
+                  readiness:
+                    properties:
+                      failureThreshold:
+                        type: "integer"
+                      initialDelaySeconds:
+                        type: "integer"
+                      path:
+                        type: "string"
+                      periodSeconds:
+                        type: "integer"
+                      port:
+                        anyOf:
+                        - type: "integer"
+                        - type: "string"
+                        x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        type: "integer"
+                    type: "object"
+                  startup:
+                    properties:
+                      failureThreshold:
+                        type: "integer"
+                      initialDelaySeconds:
+                        type: "integer"
+                      path:
+                        type: "string"
+                      periodSeconds:
+                        type: "integer"
+                      port:
+                        anyOf:
+                        - type: "integer"
+                        - type: "string"
+                        x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        type: "integer"
+                    type: "object"
+                type: "object"
               prometheus:
                 properties:
                   enabled:

--- a/examples/full-example.yaml
+++ b/examples/full-example.yaml
@@ -23,6 +23,28 @@ spec:
     requests:
       memory: "128Mi"
       cpu: "100m"
+  probes:
+    startup:
+      path: /startup
+      port: 8080
+      initialDelaySeconds: 0
+      failureThreshold: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+    readiness:
+      path: /readiness
+      port: 8080
+      initialDelaySeconds: 0
+      failureThreshold: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+    liveness:
+      path: /liveness
+      port: 8080
+      initialDelaySeconds: 20
+      failureThreshold: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
 
   strategy:
     type: RollingUpdate

--- a/examples/simple-deployment.yaml
+++ b/examples/simple-deployment.yaml
@@ -11,10 +11,13 @@ metadata:
     app.kubernetes.io/part-of: flais
     fintlabs.no/team: flais
 spec:
-  org-id: test.com
+  orgId: test.com
   replicas: 1
   port: 80
-  image: docker/getting-started
+  image: nginx
+  probes:
+    readiness:
+      path: /readiness
   resources:
     limits:
       memory: "256Mi"

--- a/src/main/kotlin/no/fintlabs/application/api/v1alpha1/FlaisApplicationSpec.kt
+++ b/src/main/kotlin/no/fintlabs/application/api/v1alpha1/FlaisApplicationSpec.kt
@@ -32,6 +32,7 @@ data class FlaisApplicationSpec(
         .addToLimits("cpu", Quantity("500m"))
         .addToLimits("memory", Quantity("512Mi"))
         .build(),
+    val probes: Probes? = null,
 
     @Min(1.0)
     val port: Int = 8080,

--- a/src/main/kotlin/no/fintlabs/application/api/v1alpha1/Probes.kt
+++ b/src/main/kotlin/no/fintlabs/application/api/v1alpha1/Probes.kt
@@ -1,0 +1,24 @@
+package no.fintlabs.application.api.v1alpha1
+
+import io.fabric8.kubernetes.api.model.IntOrString
+
+object ProbeDefaults {
+    const val FAILURE_THRESHOLD = 3
+    const val TIMEOUT_SECONDS = 1
+    const val PERIOD_SECONDS = 10
+}
+
+data class Probes(
+    val startup: Probe? = null,
+    val readiness: Probe? = null,
+    val liveness: Probe? = null,
+)
+
+data class Probe(
+    val path: String? = null,
+    val port: IntOrString? = null,
+    val initialDelaySeconds: Int? = null,
+    val failureThreshold: Int = ProbeDefaults.FAILURE_THRESHOLD,
+    val periodSeconds: Int = ProbeDefaults.PERIOD_SECONDS,
+    val timeoutSeconds: Int = ProbeDefaults.TIMEOUT_SECONDS,
+)


### PR DESCRIPTION
Adds the ability to add probes to the application container through FlaisApplication config.

Configuration can be set on `startup`, `readiness` and `liveness` probes. Only `HTTP GET` based probes are supported
```yaml
probes:
  [startup|readiness|liveness]:
      path: /path
      port: 1234
      initialDelaySeconds: 0
      failureThreshold: 5
      periodSeconds: 10
      timeoutSeconds: 3
````