### PR TITLE
Avoid reconciliation loop by nullifying zero-valued probe fields

### DIFF
--- a/src/main/kotlin/no/fintlabs/application/api/v1alpha1/Probes.kt
+++ b/src/main/kotlin/no/fintlabs/application/api/v1alpha1/Probes.kt
@@ -18,7 +18,7 @@ data class Probe(
     val path: String? = null,
     val port: IntOrString? = null,
     val initialDelaySeconds: Int? = null,
-    val failureThreshold: Int = ProbeDefaults.FAILURE_THRESHOLD,
-    val periodSeconds: Int = ProbeDefaults.PERIOD_SECONDS,
-    val timeoutSeconds: Int = ProbeDefaults.TIMEOUT_SECONDS,
+    val failureThreshold: Int? = null,
+    val periodSeconds: Int? = null,
+    val timeoutSeconds: Int? = null,
 )

--- a/src/test/unit/kotlin/no/fintlabs/application/FlaisApplicationCrdTest.kt
+++ b/src/test/unit/kotlin/no/fintlabs/application/FlaisApplicationCrdTest.kt
@@ -229,8 +229,16 @@ class FlaisApplicationCrdTest {
             FlaisApplicationSpec(
                 probes = Probes(
                     startup = Probe(),
-                    readiness = Probe(),
-                    liveness = Probe()
+                    readiness = Probe(
+                        initialDelaySeconds = 10,
+                        failureThreshold = 10,
+                        periodSeconds = 10,
+                        timeoutSeconds = 10
+                    ),
+                    liveness = Probe(
+                        path = "test-path",
+                        port = IntOrString("3000"),
+                    )
                 )
             )
         )
@@ -240,16 +248,22 @@ class FlaisApplicationCrdTest {
         assertNotNull(startupProbe)
         assertNull(startupProbe.path)
         assertNull(startupProbe.port)
-        assertEquals(ProbeDefaults.TIMEOUT_SECONDS, startupProbe.timeoutSeconds)
-        assertEquals(ProbeDefaults.PERIOD_SECONDS, startupProbe.periodSeconds)
-        assertEquals(ProbeDefaults.FAILURE_THRESHOLD, startupProbe.failureThreshold)
+        assertNull( startupProbe.timeoutSeconds)
+        assertNull(startupProbe.periodSeconds)
+        assertNull( startupProbe.failureThreshold)
         assertNull(startupProbe.initialDelaySeconds)
 
         val readinessProbe = resFlaisApplication.spec.probes?.readiness
-        assertEquals(startupProbe, readinessProbe)
+        assertNotNull(readinessProbe)
+        assertEquals(10, readinessProbe.initialDelaySeconds)
+        assertEquals(10, readinessProbe.failureThreshold)
+        assertEquals(10, readinessProbe.periodSeconds)
+        assertEquals(10, readinessProbe.timeoutSeconds)
 
         val livenessProbe = resFlaisApplication.spec.probes?.liveness
-        assertEquals(startupProbe, livenessProbe)
+        assertNotNull(livenessProbe)
+        assertEquals("test-path", livenessProbe.path)
+        assertEquals("3000", livenessProbe.port?.strVal)
     }
 
     @Test


### PR DESCRIPTION
This PR fixes probe field handling to prevent reconciliation loops. The fields `failureThreshold`, `periodSeconds`, and `timeoutSeconds` must be greater than 0; if set to 0, Kubernetes will override them with default values. `initialDelaySeconds` is allowed to be 0, and Kubernetes will accept it or default it as needed. When a field is explicitly set to a non-null value that Kubernetes overrides (e.g. 0), JOSDK detects a diff and attempts to reapply the value, leading to an endless reconciliation loop. To avoid this, zero values are now mapped to `null`, allowing Kubernetes to apply its defaults and preventing unnecessary updates.
