### PR TITLE
Testcontainers for integrationtests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,170 +1,149 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-
 plugins {
-    application
-    kotlin("jvm")
-    alias(libs.plugins.fabric8.generator)
+  application
+  kotlin("jvm")
+  alias(libs.plugins.fabric8.generator)
 }
 
 group = "no.fintlabs"
 
 sourceSets {
-    main {
-        java {
-            srcDirs(layout.buildDirectory.dir("generated/source/kubernetes/main"))
-        }
-    }
+  main { java { srcDirs(layout.buildDirectory.dir("generated/source/kubernetes/main")) } }
 }
 
-application {
-    mainClass.set("no.fintlabs.ApplicationKt")
-}
+application { mainClass.set("no.fintlabs.ApplicationKt") }
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
 dependencies {
-    implementation(kotlin("stdlib"))
-    implementation(platform(libs.koin.bom))
-    implementation(libs.koin.core)
-    implementation(libs.bundles.fabric8)
-    implementation(libs.bundles.operator)
-    implementation(libs.bundles.hoplite)
-    implementation(libs.bundles.logging)
-    implementation(libs.jackson.module.kotlin)
-    implementation(platform(libs.http4k.bom))
-    implementation(libs.bundles.http4k)
-    implementation(libs.micrometer.registry.prometheus)
+  implementation(kotlin("stdlib"))
+  implementation(platform(libs.koin.bom))
+  implementation(libs.koin.core)
+  implementation(libs.bundles.fabric8)
+  implementation(libs.bundles.operator)
+  implementation(libs.bundles.hoplite)
+  implementation(libs.bundles.logging)
+  implementation(libs.jackson.module.kotlin)
+  implementation(platform(libs.http4k.bom))
+  implementation(libs.bundles.http4k)
+  implementation(libs.micrometer.registry.prometheus)
 
-    testImplementation(kotlin("test"))
-    testImplementation(libs.mockk)
-    testImplementation(libs.awaitility.kotlin)
-    testImplementation(libs.operator.framework.junit5)
+  testImplementation(kotlin("test"))
+  testImplementation(libs.mockk)
+  testImplementation(libs.awaitility.kotlin)
+  testImplementation(libs.operator.framework.junit5)
   testImplementation(platform(libs.testcontainers.bom))
   testImplementation(libs.testcontainers.k3s)
-    testImplementation(libs.bundles.koinTest)
-    testImplementation(libs.bundles.logunit)
+  testImplementation(libs.bundles.fabric8test)
+  testImplementation(libs.bundles.koinTest)
+  testImplementation(libs.bundles.logunit)
 }
 
 testing {
-    suites {
-        @Suppress("UnstableApiUsage")
-        val test by getting(JvmTestSuite::class) {
-            testType.set(TestSuiteType.UNIT_TEST)
-            sources {
-                kotlin {
-                    srcDirs(layout.projectDirectory.dir("src/test/unit/kotlin"))
-                }
-                resources {
-                    setSrcDirs(listOf("src/test/unit/resources"))
-                }
-            }
+  suites {
+    @Suppress("UnstableApiUsage", "unused")
+    val test by
+      getting(JvmTestSuite::class) {
+        testType.set(TestSuiteType.UNIT_TEST)
+        sources {
+          kotlin { srcDirs(layout.projectDirectory.dir("src/test/unit/kotlin")) }
+          resources { setSrcDirs(listOf("src/test/unit/resources")) }
+        }
+      }
+
+    @Suppress("UnstableApiUsage", "unused")
+    val integrationTest by
+      registering(JvmTestSuite::class) {
+        testType.set(TestSuiteType.INTEGRATION_TEST)
+        sources {
+          kotlin { srcDirs(layout.projectDirectory.dir("src/test/integration/kotlin")) }
+          resources { setSrcDirs(listOf("src/test/integration/resources")) }
         }
 
-        @Suppress("UnstableApiUsage")
-        val integrationTest by registering(JvmTestSuite::class) {
-            testType.set(TestSuiteType.INTEGRATION_TEST)
-            sources {
-                kotlin {
-                    srcDirs(layout.projectDirectory.dir("src/test/integration/kotlin"))
-                }
-                resources {
-                    setSrcDirs(listOf("src/test/integration/resources"))
-                }
-            }
-
-            dependencies {
-                // We can replace direct dependency on test's runtimeClasspath with implementation(project())
-                // once https://github.com/gradle/gradle/issues/25269 is resolved
-                implementation(sourceSets.test.get().runtimeClasspath)
-                implementation(sourceSets.test.get().output)
-            }
+        dependencies {
+          // We can replace direct dependency on test's runtimeClasspath with
+          // implementation(project())
+          // once https://github.com/gradle/gradle/issues/25269 is resolved
+          implementation(sourceSets.test.get().runtimeClasspath)
+          implementation(sourceSets.test.get().output)
         }
-    }
+      }
+  }
 }
 
 tasks {
-    withType<Wrapper> {
-        gradleVersion = "8.12"
+  withType<Wrapper> { gradleVersion = "8.12" }
+
+  java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
+
+  withType<KotlinCompile> {
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_21
+      freeCompilerArgs.add("-Xjsr305=strict")
+    }
+  }
+
+  jar {
+    archiveBaseName = "app"
+    manifest {
+      attributes["Main-Class"] = "no.fintlabs.ApplicationKt"
+      attributes["Class-Path"] =
+        configurations.runtimeClasspath.get().joinToString(separator = " ") { it.name }
     }
 
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+    val configuration = configurations.runtimeClasspath.get().map { it.toPath().toFile() }
+    val buildDirectory = layout.buildDirectory
+
+    doLast {
+      configuration.forEach {
+        val file = buildDirectory.file("libs/${it.name}").get().asFile
+        if (!file.exists()) {
+          it.copyTo(file)
         }
+      }
     }
+  }
 
-    withType<KotlinCompile> {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_21
-            freeCompilerArgs.add("-Xjsr305=strict")
-        }
-    }
+  javaGen {
+    source = file(layout.projectDirectory.dir("src/main/resources/kubernetes"))
+    target = file(layout.buildDirectory.dir("generated/source/kubernetes/main"))
+  }
 
-    jar {
-        archiveBaseName = "app"
-        manifest {
-            attributes["Main-Class"] = "no.fintlabs.ApplicationKt"
-            attributes["Class-Path"] =
-                configurations.runtimeClasspath.get().joinToString(separator = " ") {
-                    it.name
-                }
-        }
+  compileKotlin { dependsOn(crd2java) }
 
-        val configuration = configurations.runtimeClasspath.get().map {
-            it.toPath().toFile()
-        }
-        val buildDirectory = layout.buildDirectory
+  withType<Test> {
+    useJUnitPlatform()
 
-        doLast {
-            configuration.forEach {
-                val file = buildDirectory
-                        .file("libs/${it.name}")
-                        .get()
-                        .asFile
-                if (!file.exists()) {
-                    it.copyTo(file)
-                }
-            }
-        }
-    }
+    maxParallelForks = fetchNumCores()
+    forkEvery = 1
 
-    javaGen {
-        source = file(layout.projectDirectory.dir("src/main/resources/kubernetes"))
-        target = file(layout.buildDirectory.dir("generated/source/kubernetes/main"))
-    }
+    testLogging { exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL }
+  }
 
-    compileKotlin {
-        dependsOn(crd2java)
-    }
+  register<GenerateCrdsTask>("generateCrds") {
+    description =
+      "Generate CRDs from the compiled custom resource class `no.fintlabs.application.api.v1alpha1.FlaisApplicationCrd`"
+    group = "crd"
 
-    withType<Test> {
-        useJUnitPlatform()
+    sourceSet = sourceSets["main"]
+    includePackages = listOf("no.fintlabs.application.api")
+    targetDirectory =
+      project.layout.projectDirectory.dir("charts/flaiserator-crd/charts/crds/templates")
 
-        maxParallelForks = fetchNumCores()
-        forkEvery = 1
-
-        testLogging {
-            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-        }
-    }
-
-    register<GenerateCrdsTask>("generateCrds") {
-        description = "Generate CRDs from the compiled custom resource class `no.fintlabs.application.api.v1alpha1.FlaisApplicationCrd`"
-        group = "crd"
-
-        sourceSet = sourceSets["main"]
-        includePackages = listOf("no.fintlabs.application.api")
-        targetDirectory = project.layout.projectDirectory.dir("charts/flaiserator-crd/charts/crds/templates")
-
-        dependsOn(compileJava, compileKotlin)
-    }
+    dependsOn(compileJava, compileKotlin)
+  }
 }
 
-fun fetchNumCores(): Int = Runtime.getRuntime().availableProcessors().let {
-    if (System.getenv("CI") != null) it
-    else it / 2
-}.coerceAtLeast(1)
+fun fetchNumCores(): Int =
+  Runtime.getRuntime()
+    .availableProcessors()
+    .let {
+      if (System.getenv("CI") != null) {
+        it
+      } else {
+        it / 2
+      }
+    }
+    .coerceAtLeast(1)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.awaitility.kotlin)
     testImplementation(libs.operator.framework.junit5)
+    testImplementation(libs.testcontainers.k3s)
     testImplementation(libs.bundles.fabric8test)
     testImplementation(libs.bundles.koinTest)
     testImplementation(libs.bundles.logunit)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,8 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.awaitility.kotlin)
     testImplementation(libs.operator.framework.junit5)
-    testImplementation(libs.testcontainers.k3s)
-    testImplementation(libs.bundles.fabric8test)
+  testImplementation(platform(libs.testcontainers.bom))
+  testImplementation(libs.testcontainers.k3s)
     testImplementation(libs.bundles.koinTest)
     testImplementation(libs.bundles.logunit)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ operator-framework-junit5 = { module = "io.javaoperatorsdk:operator-framework-ju
 awaitility-kotlin = { module = "org.awaitility:awaitility-kotlin", version.ref = "awaitility" }
 logunit-core = { module = "io.github.netmikey.logunit:logunit-core", version.ref = "logunit"}
 logunit-logback = { module = "io.github.netmikey.logunit:logunit-logback", version.ref = "logunit"}
+testcontainers-k3s = { module = "org.testcontainers:k3s", version="1.21.3" }
 
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,8 @@ operator-framework-junit5 = { module = "io.javaoperatorsdk:operator-framework-ju
 awaitility-kotlin = { module = "org.awaitility:awaitility-kotlin", version.ref = "awaitility" }
 logunit-core = { module = "io.github.netmikey.logunit:logunit-core", version.ref = "logunit"}
 logunit-logback = { module = "io.github.netmikey.logunit:logunit-logback", version.ref = "logunit"}
-testcontainers-k3s = { module = "org.testcontainers:k3s", version="1.21.3" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version="1.21.3"}
+testcontainers-k3s = { module = "org.testcontainers:k3s" }
 
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core" }

--- a/src/test/integration/kotlin/no/fintlabs/application/DeploymentDRTest.kt
+++ b/src/test/integration/kotlin/no/fintlabs/application/DeploymentDRTest.kt
@@ -12,7 +12,7 @@ import no.fintlabs.application.Utils.createKoinTestExtension
 import no.fintlabs.application.Utils.createKubernetesOperatorExtension
 import no.fintlabs.application.Utils.createTestFlaisApplication
 import no.fintlabs.application.Utils.updateAndGetResource
-import no.fintlabs.application.Utils.waitUntilIsDeployed
+import no.fintlabs.application.Utils.waitUntil
 import no.fintlabs.application.api.LOKI_LOGGING_LABEL
 import no.fintlabs.application.api.v1alpha1.*
 import no.fintlabs.application.api.v1alpha1.Probe
@@ -23,6 +23,7 @@ import no.fintlabs.v1alpha1.kafkauserandaclspec.Acls
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.koin.dsl.module
+import java.time.Duration
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -523,7 +524,10 @@ class DeploymentDRTest {
         context.create(deployment)
 
         context.operator.start()
-        context.waitUntilIsDeployed(flaisApplication)
+        context.waitUntil<FlaisApplicationCrd>(deployment.metadata.name, pollDelay = Duration.ofSeconds(5)) {
+            it.status.state == FlaisApplicationState.DEPLOYED
+        }
+
         deployment = context.get<Deployment>(deployment.metadata.name)
 
         assertNotNull(deployment)

--- a/src/test/integration/kotlin/no/fintlabs/extensions/KubernetesOperatorExtension.kt
+++ b/src/test/integration/kotlin/no/fintlabs/extensions/KubernetesOperatorExtension.kt
@@ -29,175 +29,203 @@ import java.io.ByteArrayOutputStream
 import java.time.Duration
 
 class KubernetesOperatorExtension
-private constructor(private val crdClass: List<Class<out CustomResource<*, *>>>) : BeforeEachCallback,
-    BeforeAllCallback, AfterAllCallback, AfterEachCallback, ParameterResolver, KoinComponent {
-    private val k3s: K3sContainer
-    private val namespaceSupplier = DefaultNamespaceNameSupplier()
+    private constructor(
+        private val crdClass: List<Class<out CustomResource<*, *>>>,
+    ) : BeforeEachCallback,
+        BeforeAllCallback,
+        AfterAllCallback,
+        AfterEachCallback,
+        ParameterResolver,
+        KoinComponent {
+        private val k3s: K3sContainer
+        private val namespaceSupplier = DefaultNamespaceNameSupplier()
 
-    private var additionalResources = emptyList<KubernetesResourceSource>()
+        private var additionalResources = emptyList<KubernetesResourceSource>()
 
-    init {
-        val kubernetesVersion = System.getenv("TEST_KUBERNETES_VERSION") ?: "v1.33.3"
-        k3s = K3sContainer(DockerImageName.parse("rancher/k3s:$kubernetesVersion-k3s1"))
-    }
-
-    override fun beforeAll(context: ExtensionContext) {
-        prepareAdditionalResources(context)
-        k3s.start()
-        ensureCRDs()
-    }
-
-    override fun afterAll(context: ExtensionContext) {
-        k3s.stop()
-    }
-
-    override fun beforeEach(context: ExtensionContext) {
-        val operatorConfig = getKubernetesOperatorConfig(context)
-        val namespace = namespaceSupplier.apply(context)
-        val kubernetesClient = createKubernetesClient(namespace, get())
-
-        prepareKoin(kubernetesClient)
-        prepareKubernetes(kubernetesClient, namespace)
-        applyAdditionalResources(kubernetesClient, namespace)
-
-        context.store()
-            .put(KubernetesOperatorContext::class.simpleName, KubernetesOperatorContext(namespace, kubernetesClient) {
-                get<Operator>()
-            })
-
-        if (!operatorConfig.explicitStart) {
-            val operator = get<Operator>()
-            operator.start()
+        init {
+            val kubernetesVersion = System.getenv("TEST_KUBERNETES_VERSION") ?: "v1.33.3"
+            k3s =
+                K3sContainer(DockerImageName.parse("rancher/k3s:$kubernetesVersion-k3s1"))
+                    .withReuse(true)
         }
-    }
 
-    override fun afterEach(context: ExtensionContext) {
-        val kubernetesOperatorContext =
-            context.store().get(KubernetesOperatorContext::class.simpleName) as KubernetesOperatorContext
-        val kubernetesClient = kubernetesOperatorContext.kubernetesClient
-
-        cleanupKubernetes(kubernetesClient, kubernetesOperatorContext.namespace)
-
-        kubernetesOperatorContext.operator.stop()
-        kubernetesClient.close()
-    }
-
-    override fun supportsParameter(pContext: ParameterContext, eContext: ExtensionContext): Boolean =
-        pContext.parameter.type == KubernetesOperatorContext::class.java
-
-    override fun resolveParameter(pContext: ParameterContext, eContext: ExtensionContext): Any =
-        eContext.store().get(KubernetesOperatorContext::class.simpleName)
-
-
-    private fun ensureCRDs() {
-        val crds = prepareCRDs()
-        val kubernetesClient = createKubernetesClient()
-        crds.forEach { crd ->
-            kubernetesClient.load(ByteArrayInputStream(crd.toByteArray())).serverSideApply()
+        override fun beforeAll(context: ExtensionContext) {
+            prepareAdditionalResources(context)
+            k3s.start()
+            ensureCRDs()
         }
-        await atMost Duration.ofSeconds(30) until { crds.all { kubernetesClient.resource(it).get() != null } }
 
-        kubernetesClient.close()
-    }
+        override fun afterAll(context: ExtensionContext) {
+            k3s.stop()
+        }
 
-    private fun prepareCRDs(): List<String> {
-        val output = InMemoryCRDOutput()
-        val crdGenerator = CRDGenerator()
-            .customResourceClasses(*crdClass.toTypedArray())
-            .withOutput(output)
-            .forCRDVersions("v1")
-        crdGenerator.generate()
-        return output.getCRDs().also { output.close() }
-    }
+        override fun beforeEach(context: ExtensionContext) {
+            val operatorConfig = getKubernetesOperatorConfig(context)
+            val namespace = namespaceSupplier.apply(context)
+            val kubernetesClient = createKubernetesClient(namespace, get())
 
-    private fun prepareKoin(kubernetesClient: KubernetesClient) {
-        getKoin().apply {
-            loadKoinModules(
-                module {
-                    single { kubernetesClient }
-                    single(named("test")) { OperatorConfigHandler {
-                        it.setCloseClientOnStop(false)
-                    } }
-                    single {
-                        OperatorPostConfigHandler { operator ->
-                            getAll<Reconciler<*>>().forEach {
-                                operator.register(it) { config ->
-                                    config.settingNamespace(kubernetesClient.namespace)
+            prepareKoin(kubernetesClient)
+            prepareKubernetes(kubernetesClient, namespace)
+            applyAdditionalResources(kubernetesClient, namespace)
+
+            context
+                .store()
+                .put(
+                    KubernetesOperatorContext::class.simpleName,
+                    KubernetesOperatorContext(namespace, kubernetesClient) {
+                        get<Operator>()
+                    },
+                )
+
+            if (!operatorConfig.explicitStart) {
+                val operator = get<Operator>()
+                operator.start()
+            }
+        }
+
+        override fun afterEach(context: ExtensionContext) {
+            val kubernetesOperatorContext =
+                context.store().get(KubernetesOperatorContext::class.simpleName) as KubernetesOperatorContext
+            val kubernetesClient = kubernetesOperatorContext.kubernetesClient
+
+            cleanupKubernetes(kubernetesClient, kubernetesOperatorContext.namespace)
+
+            kubernetesOperatorContext.operator.stop()
+            kubernetesClient.close()
+        }
+
+        override fun supportsParameter(
+            pContext: ParameterContext,
+            eContext: ExtensionContext,
+        ): Boolean = pContext.parameter.type == KubernetesOperatorContext::class.java
+
+        override fun resolveParameter(
+            pContext: ParameterContext,
+            eContext: ExtensionContext,
+        ): Any = eContext.store().get(KubernetesOperatorContext::class.simpleName)
+
+        private fun ensureCRDs() {
+            val crds = prepareCRDs()
+            val kubernetesClient = createKubernetesClient()
+            crds.forEach { crd ->
+                kubernetesClient.load(ByteArrayInputStream(crd.toByteArray())).serverSideApply()
+            }
+            await atMost Duration.ofSeconds(30) until { crds.all { kubernetesClient.resource(it).get() != null } }
+
+            kubernetesClient.close()
+        }
+
+        private fun prepareCRDs(): List<String> {
+            val output = InMemoryCRDOutput()
+            val crdGenerator =
+                CRDGenerator()
+                    .customResourceClasses(*crdClass.toTypedArray())
+                    .withOutput(output)
+                    .forCRDVersions("v1")
+            crdGenerator.generate()
+            return output.getCRDs().also { output.close() }
+        }
+
+        private fun prepareKoin(kubernetesClient: KubernetesClient) {
+            getKoin().apply {
+                loadKoinModules(
+                    module {
+                        single { kubernetesClient }
+                        single(named("test")) {
+                            OperatorConfigHandler {
+                                it.setCloseClientOnStop(false)
+                            }
+                        }
+                        single {
+                            OperatorPostConfigHandler { operator ->
+                                getAll<Reconciler<*>>().forEach {
+                                    operator.register(it) { config ->
+                                        config.settingNamespace(kubernetesClient.namespace)
+                                    }
                                 }
                             }
                         }
-                    }
+                    },
+                )
+            }
+        }
+
+        private fun prepareKubernetes(
+            kubernetesClient: KubernetesClient,
+            namespace: String,
+        ) {
+            val namespaceResource =
+                Namespace().apply {
+                    metadata =
+                        io.fabric8.kubernetes.api.model.ObjectMeta().apply {
+                            name = namespace
+                        }
                 }
-            )
+            kubernetesClient.namespaces().resource(namespaceResource).create()
         }
-    }
 
-    private fun prepareKubernetes(kubernetesClient: KubernetesClient, namespace: String) {
-        val namespaceResource = Namespace().apply {
-            metadata = io.fabric8.kubernetes.api.model.ObjectMeta().apply {
-                name = namespace
+        private fun cleanupKubernetes(
+            kubernetesClient: KubernetesClient,
+            namespace: String,
+        ) {
+            kubernetesClient.namespaces().withName(namespace).delete()
+        }
+
+        private fun ExtensionContext.store(): ExtensionContext.Store = this.getStore(KUBERNETES_OPERATOR_STORE)
+
+        private fun createKubernetesClient(
+            namespace: String? = null,
+            serializer: ObjectMapper? = null,
+        ): KubernetesClient =
+            KubernetesClientBuilder()
+                .apply {
+                    withConfig(
+                        Config.fromKubeconfig(k3s.kubeConfigYaml).apply {
+                            setNamespace(namespace)
+                        },
+                    )
+                    if (serializer != null) {
+                        withKubernetesSerialization(KubernetesSerialization(serializer, true))
+                    }
+                }.build()
+
+        private fun prepareAdditionalResources(context: ExtensionContext) {
+            context.element.ifPresent {
+                it.getAnnotation(KubernetesResources::class.java)?.let { kubernetesResource ->
+                    additionalResources = KubernetesResourceSource.fromResources(kubernetesResource.paths.toList())
+                }
             }
         }
-        kubernetesClient.namespaces().resource(namespaceResource).create()
-    }
 
-    private fun cleanupKubernetes(kubernetesClient: KubernetesClient, namespace: String) {
-        kubernetesClient.namespaces().withName(namespace).delete()
-    }
-
-    private fun ExtensionContext.store(): ExtensionContext.Store {
-        return this.getStore(KUBERNETES_OPERATOR_STORE)
-    }
-
-    private fun createKubernetesClient(namespace: String? = null, serializer: ObjectMapper? = null): KubernetesClient {
-        return KubernetesClientBuilder().apply {
-            withConfig(Config.fromKubeconfig(k3s.kubeConfigYaml).apply {
-                setNamespace(namespace)
-            })
-            if (serializer != null) {
-                withKubernetesSerialization(KubernetesSerialization(serializer, true))
-            }
-        }.build()
-    }
-
-    private fun prepareAdditionalResources(context: ExtensionContext) {
-        context.element.ifPresent {
-            it.getAnnotation(KubernetesResources::class.java)?.let { kubernetesResource ->
-                additionalResources = KubernetesResourceSource.fromResources(kubernetesResource.paths.toList())
+        private fun applyAdditionalResources(
+            kubernetesClient: KubernetesClient,
+            namespace: String,
+        ) {
+            additionalResources.forEach { resource ->
+                resource.open()?.use { inputStream ->
+                    kubernetesClient.load(inputStream).inNamespace(namespace).serverSideApply()
+                }
             }
         }
-    }
 
-    private fun applyAdditionalResources(kubernetesClient: KubernetesClient, namespace: String) {
-        additionalResources.forEach { resource ->
-            resource.open()?.use { inputStream ->
-                kubernetesClient.load(inputStream).inNamespace(namespace).serverSideApply()
-            }
+        private fun getKubernetesOperatorConfig(context: ExtensionContext): KubernetesOperator =
+            context.requiredTestMethod.getAnnotation(KubernetesOperator::class.java) ?: KubernetesOperator()
+
+        companion object {
+            fun create(crdClass: List<Class<out CustomResource<*, *>>> = emptyList()) = KubernetesOperatorExtension(crdClass)
+
+            private val KUBERNETES_OPERATOR_STORE: ExtensionContext.Namespace =
+                ExtensionContext.Namespace.create("KUBERNETES_OPERATOR_STORE")
         }
     }
-
-    private fun getKubernetesOperatorConfig(context: ExtensionContext): KubernetesOperator =
-        context.requiredTestMethod.getAnnotation(KubernetesOperator::class.java) ?: KubernetesOperator()
-
-    companion object {
-        fun create(crdClass: List<Class<out CustomResource<*, *>>> = emptyList()) =
-            KubernetesOperatorExtension(crdClass)
-
-        private val KUBERNETES_OPERATOR_STORE: ExtensionContext.Namespace =
-            ExtensionContext.Namespace.create("KUBERNETES_OPERATOR_STORE")
-    }
-}
 
 class InMemoryCRDOutput : CRDGenerator.AbstractCRDOutput<ByteArrayOutputStream>() {
     private val streams = mutableListOf<ByteArrayOutputStream>()
 
-    override fun createStreamFor(crdName: String): ByteArrayOutputStream {
-        return ByteArrayOutputStream().also {
+    override fun createStreamFor(crdName: String): ByteArrayOutputStream =
+        ByteArrayOutputStream().also {
             streams.add(it)
         }
-    }
 
-    fun getCRDs(): List<String> {
-        return streams.map { it.toString() }
-    }
+    fun getCRDs(): List<String> = streams.map { it.toString() }
 }

--- a/src/test/integration/kotlin/no/fintlabs/extensions/KubernetesOperatorExtension.kt
+++ b/src/test/integration/kotlin/no/fintlabs/extensions/KubernetesOperatorExtension.kt
@@ -2,9 +2,6 @@ package no.fintlabs.extensions
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.fabric8.crdv2.generator.CRDGenerator
-import io.fabric8.kubeapitest.KubeAPIServer
-import io.fabric8.kubeapitest.KubeAPIServerConfigBuilder
-import io.fabric8.kubeapitest.KubeAPIServerConfigBuilder.KUBE_API_TEST_OFFLINE_MODE
 import io.fabric8.kubernetes.api.model.Namespace
 import io.fabric8.kubernetes.client.Config
 import io.fabric8.kubernetes.client.CustomResource
@@ -25,6 +22,8 @@ import org.koin.core.component.get
 import org.koin.core.context.loadKoinModules
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.testcontainers.k3s.K3sContainer
+import org.testcontainers.utility.DockerImageName
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.time.Duration
@@ -32,21 +31,24 @@ import java.time.Duration
 class KubernetesOperatorExtension
 private constructor(private val crdClass: List<Class<out CustomResource<*, *>>>) : BeforeEachCallback,
     BeforeAllCallback, AfterAllCallback, AfterEachCallback, ParameterResolver, KoinComponent {
-    private val kubernetesApi = KubeAPIServer(KubeAPIServerConfigBuilder().apply {
-        withOfflineMode(System.getenv(KUBE_API_TEST_OFFLINE_MODE).toBoolean())
-    }.build())
+    private val k3s: K3sContainer
     private val namespaceSupplier = DefaultNamespaceNameSupplier()
 
     private var additionalResources = emptyList<KubernetesResourceSource>()
 
+    init {
+        val kubernetesVersion = System.getenv("TEST_KUBERNETES_VERSION") ?: "v1.33.3"
+        k3s = K3sContainer(DockerImageName.parse("rancher/k3s:$kubernetesVersion-k3s1"))
+    }
+
     override fun beforeAll(context: ExtensionContext) {
         prepareAdditionalResources(context)
-        kubernetesApi.start()
+        k3s.start()
         ensureCRDs()
     }
 
     override fun afterAll(context: ExtensionContext) {
-        kubernetesApi.stop()
+        k3s.stop()
     }
 
     override fun beforeEach(context: ExtensionContext) {
@@ -149,7 +151,7 @@ private constructor(private val crdClass: List<Class<out CustomResource<*, *>>>)
 
     private fun createKubernetesClient(namespace: String? = null, serializer: ObjectMapper? = null): KubernetesClient {
         return KubernetesClientBuilder().apply {
-            withConfig(Config.fromKubeconfig(kubernetesApi.kubeConfigYaml).apply {
+            withConfig(Config.fromKubeconfig(k3s.kubeConfigYaml).apply {
                 setNamespace(namespace)
             })
             if (serializer != null) {


### PR DESCRIPTION
Flaiserator’s integration tests have been unreliable — failing almost every time in GitHub Actions and intermittently when run locally. The current setup relies on Kubebuilder EnvTest to simulate a Kubernetes API, but EnvTest frequently fails to initialize correctly, especially under parallel execution where each test class spawns its own instance.

This PR migrates the integration tests to use Testcontainers k3s, which provides a lightweight, reproducible Kubernetes cluster inside a container. This approach ensures consistent behavior across local and CI environments, maintains test isolation, and resolves many of the initialization issues observed with EnvTest.