### PR TITLE
refactor: rewrite synchronization hash as SHA-256 string

### DIFF
--- a/charts/flaiserator-crd/charts/crds/templates/applications.fintlabs.no-v1.yml
+++ b/charts/flaiserator-crd/charts/crds/templates/applications.fintlabs.no-v1.yml
@@ -335,6 +335,8 @@ spec:
                 - "FAILED"
                 - "PENDING"
                 type: "string"
+              synchronizationHash:
+                type: "string"
             type: "object"
         type: "object"
     served: true

--- a/charts/flaiserator-crd/charts/crds/templates/jobs.fintlabs.no-v1.yml
+++ b/charts/flaiserator-crd/charts/crds/templates/jobs.fintlabs.no-v1.yml
@@ -215,6 +215,8 @@ spec:
                 - "FAILED"
                 - "PENDING"
                 type: "string"
+              synchronizationHash:
+                type: "string"
             type: "object"
         type: "object"
     served: true

--- a/src/main/kotlin/no/fintlabs/common/api/v1alpha1/FlaisResource.kt
+++ b/src/main/kotlin/no/fintlabs/common/api/v1alpha1/FlaisResource.kt
@@ -3,7 +3,7 @@ package no.fintlabs.common.api.v1alpha1
 import io.fabric8.kubernetes.api.model.Namespaced
 import io.fabric8.kubernetes.api.model.ObjectMeta
 import io.fabric8.kubernetes.client.CustomResource
-import no.fintlabs.common.utils.createIntHash
+import no.fintlabs.common.utils.createHash
 
 abstract class FlaisResource<T : FlaisResourceSpec> :
     CustomResource<T, FlaisResourceStatus>(), Namespaced
@@ -20,12 +20,12 @@ fun <T : FlaisResource<*>> T.clone(): T {
   }
 }
 
-fun <T : FlaisResource<*>> T.resourceHash(): Int {
+fun <T : FlaisResource<*>> T.resourceHash(): String {
   val values =
       mapOf(
           "spec" to spec,
           "labels" to metadata.labels,
           "changeCause" to metadata.annotations?.get("kubernetes.io/change-cause"),
       )
-  return createIntHash(values)
+  return createHash(values)
 }

--- a/src/main/kotlin/no/fintlabs/common/api/v1alpha1/FlaisResourceStatus.kt
+++ b/src/main/kotlin/no/fintlabs/common/api/v1alpha1/FlaisResourceStatus.kt
@@ -5,5 +5,5 @@ data class FlaisResourceStatus(
     val state: FlaisResourceState = FlaisResourceState.PENDING,
     val correlationId: String? = null,
     val errors: List<StatusError>? = null,
-    val synchronizationHash: Int? = null,
+    val synchronizationHash: String? = null,
 )

--- a/src/main/kotlin/no/fintlabs/common/utils/HashUtils.kt
+++ b/src/main/kotlin/no/fintlabs/common/utils/HashUtils.kt
@@ -3,11 +3,14 @@ package no.fintlabs.common.utils
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import java.util.Objects
+import java.security.MessageDigest
 
 private val mapper =
     ObjectMapper()
         .registerKotlinModule()
         .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
 
-fun createIntHash(map: Map<*, *>): Int = Objects.hashCode(mapper.writeValueAsString(map))
+fun createHash(map: Map<*, *>): String {
+  val json = mapper.writeValueAsBytes(map)
+  return MessageDigest.getInstance("SHA-256").digest(json).joinToString("") { "%02x".format(it) }
+}

--- a/src/test/unit/kotlin/no/fintlabs/common/FlaisResourceReconciliationFilterTest.kt
+++ b/src/test/unit/kotlin/no/fintlabs/common/FlaisResourceReconciliationFilterTest.kt
@@ -20,7 +20,7 @@ class FlaisResourceReconciliationFilterTest {
   @Test
   fun `should reconcile when synchronization hash differs`() {
     val resource = buildResource()
-    resource.status = buildStatus(resource, synchronizationHash = 123)
+    resource.status = buildStatus(resource, synchronizationHash = "123")
 
     assertTrue(FlaisResourceReconciliationFilter.shouldReconcile(resource))
   }
@@ -88,7 +88,7 @@ class FlaisResourceReconciliationFilterTest {
       state: FlaisResourceState = FlaisResourceState.DEPLOYED,
       correlationId: String? =
           resource.metadata.annotations["fintlabs.no/deployment-correlation-id"],
-      synchronizationHash: Int = resource.resourceHash(),
+      synchronizationHash: String = resource.resourceHash(),
   ): FlaisResourceStatus =
       FlaisResourceStatus(
           observedGeneration = observedGeneration,


### PR DESCRIPTION
## Summary
- rewrite synchronization hash generation to SHA-256 hex string
- change synchronizationHash type in FlaisResourceStatus from Int to String
- switch hashing from writeValueAsString to writeValueAsBytes
- update reconciliation filter test and regenerated CRD templates for the status schema change

## Notes
- This is a refactor/rewrite; behavior remains the same except hash representation format.