### PR TITLE
Downgrade netty to 4.1.133.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ jackson = "2.21.3"
 logunit = "2.0.0"
 http4k = "6.46.0.0"
 micrometer = "1.16.5"
-netty = "4.2.13.Final"
+netty = "4.1.133.Final"
 
 [libraries]
 fabric8-kubernetes-client = { module = "io.fabric8:kubernetes-client", version.ref = "fabric8" }


### PR DESCRIPTION
Downgrades the Netty BOM from `4.2.13.Final` back to `4.1.133.Final`.

`4.2.13.Final` is a major-line jump and is not a safe patch-only update for this repo’s current dependency set. The project currently resolves cleanly on `4.1.133.Final`, which fixes the vulnerable `4.1.130.Final` transitive Netty versions while staying on the same `4.1.x` line used by the dependent libraries.
