### PR TITLE
Override bouncycastle version to 1.84 for CVE-2026-5598

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,16 @@ dependencies {
   testImplementation(libs.bundles.fabric8test)
   testImplementation(libs.bundles.koinTest)
   testImplementation(libs.logcapturer)
+
+  constraints {
+    testImplementation("org.bouncycastle:bcpkix-jdk18on") {
+      version {
+        require("1.84")
+      }
+      because("Override bouncycastle version due to vulnerability in version < 1.84. " +
+              "Used in io.fabric8:kubernetes-server-mock and io.fabric8:kube-api-test")
+    }
+  }
 }
 
 testing {


### PR DESCRIPTION
Overrides the bouncycastle dependency version to `1.84` to address `CVE-2026-5598`.