### PR TITLE
Support Traefik v3 ingress CRDs

### DIFF
--- a/charts/flaiserator/templates/deployment.yaml
+++ b/charts/flaiserator/templates/deployment.yaml
@@ -44,10 +44,13 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.env }}
+
           env:
-              {{- toYaml . | nindent 12 }}
-          {{- end }}
+            - name: FLAISERATOR_INGRESS_TRAEFIKV3CRDSUPPORT
+              value: {{ .Values.config.ingress.traefikV3CrdSupport | quote }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 
           livenessProbe:
             httpGet:
@@ -70,4 +73,3 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-

--- a/charts/flaiserator/values.yaml
+++ b/charts/flaiserator/values.yaml
@@ -39,3 +39,7 @@ resources:
 volumes: []
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
+
+config:
+    ingress:
+        traefikV3CrdSupport: false

--- a/src/main/kotlin/no/fintlabs/Config.kt
+++ b/src/main/kotlin/no/fintlabs/Config.kt
@@ -4,8 +4,13 @@ import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.PropertySource
 import org.slf4j.LoggerFactory
 
+data class IngressConfig(
+    val traefikV3CrdSupport: Boolean = false,
+)
+
 data class Config(
     val imagePullSecrets: List<String> = emptyList(),
+    val ingress: IngressConfig = IngressConfig(),
 )
 
 private val logger = LoggerFactory.getLogger("Config")

--- a/src/main/kotlin/no/fintlabs/application/ApplicationReconciler.kt
+++ b/src/main/kotlin/no/fintlabs/application/ApplicationReconciler.kt
@@ -32,6 +32,7 @@ import org.koin.core.component.KoinComponent
         Dependent(PostgresUserDR::class),
         Dependent(OnePasswordDR::class),
         Dependent(KafkaDR::class),
+        Dependent(IngressV3DR::class),
     ],
 )
 class ApplicationReconciler :

--- a/src/main/kotlin/no/fintlabs/application/ApplicationReconcilerModule.kt
+++ b/src/main/kotlin/no/fintlabs/application/ApplicationReconcilerModule.kt
@@ -15,6 +15,7 @@ fun applicationReconcilerModule() =
         single { ServiceDR() }
         single { PodMetricsDR() }
         single { IngressDR() }
+        single { IngressV3DR() }
         single { OnePasswordDR<FlaisApplication>() }
         single { PostgresUserDR<FlaisApplication>() }
         single { KafkaDR<FlaisApplication>() }

--- a/src/main/kotlin/no/fintlabs/application/IngressV3DR.kt
+++ b/src/main/kotlin/no/fintlabs/application/IngressV3DR.kt
@@ -1,0 +1,152 @@
+package no.fintlabs.application
+
+import io.fabric8.kubernetes.api.model.IntOrString
+import io.javaoperatorsdk.operator.api.config.informer.Informer
+import io.javaoperatorsdk.operator.api.reconciler.Context
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
+import io.traefik.v1alpha1.IngressRoute
+import io.traefik.v1alpha1.IngressRouteSpec
+import io.traefik.v1alpha1.ingressroutespec.Routes
+import io.traefik.v1alpha1.ingressroutespec.routes.Middlewares
+import io.traefik.v1alpha1.ingressroutespec.routes.Services
+import no.fintlabs.Config
+import no.fintlabs.application.api.MANAGED_BY_FLAISERATOR_SELECTOR
+import no.fintlabs.application.api.v1alpha1.FlaisApplication
+import no.fintlabs.application.api.v1alpha1.Ingress.Route
+import no.fintlabs.application.api.v1alpha1.isIngressEnabled
+import no.fintlabs.application.api.v1alpha1.isLegacy
+import no.fintlabs.common.utils.createObjectMeta
+import no.fintlabs.operator.dependent.ReconcileCondition
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+@KubernetesDependent(informer = Informer(labelSelector = MANAGED_BY_FLAISERATOR_SELECTOR))
+class IngressV3DR :
+    CRUDKubernetesDependentResource<IngressRoute, FlaisApplication>(IngressRoute::class.java),
+    ReconcileCondition<FlaisApplication>,
+    KoinComponent {
+    val config: Config by inject()
+
+    override fun name(): String = "ingress-v3"
+
+    override fun desired(
+        primary: FlaisApplication,
+        context: Context<FlaisApplication>,
+    ) = IngressRoute().apply {
+        metadata = createObjectMeta(primary)
+        spec =
+            IngressRouteSpec().apply {
+                entryPoints = listOf("web")
+                routes =
+                    primary.spec.ingress!!.let { ingress ->
+                        if (ingress.isLegacy()) {
+                            listOf(createLegacyAppRoute(primary))
+                        } else {
+                            ingress.routes!!.map { createAppRoute(it, primary) }
+                        }
+                    }
+            }
+    }
+
+    private fun createAppRoute(
+        route: Route,
+        primary: FlaisApplication,
+    ) = Routes().apply {
+        kind = Routes.Kind.RULE
+        match = createMatch(route)
+        services =
+            listOf(
+                Services().apply {
+                    port = IntOrString(primary.spec.port)
+                    name = primary.metadata.name
+                    namespace = primary.metadata.namespace
+                },
+            )
+        middlewares =
+            route.allMiddlewares
+                .map {
+                    Middlewares().apply {
+                        name = it
+                        namespace = primary.metadata.namespace
+                    }
+                }.ifEmpty { null }
+    }
+
+    private fun createMatch(route: Route) =
+        buildString {
+            append("Host(`${route.host}`)")
+            route.path
+                ?.takeIf { it.isNotEmpty() }
+                ?.let {
+                    append(" && ")
+                    append("PathPrefix(`$it`)")
+                }
+            route.queries
+                ?.filter { it.key.isNotEmpty() && it.value.isNotEmpty() }
+                ?.map { (key, value) -> "`$key=$value`" }
+                ?.let {
+                    append(" && ")
+                    append("Query(${it.joinToString(", ")})")
+                }
+            route.headers
+                ?.filter { it.key.isNotEmpty() && it.value.isNotEmpty() }
+                ?.forEach { (key, value) ->
+                    append(" && ")
+                    append(
+                        if (value.isRegex()) {
+                            "HeadersRegexp(`$key`, `${value.stripRegexPrefix().toRegex()}`)"
+                        } else {
+                            "Headers(`$key`, `$value`)"
+                        },
+                    )
+                }
+        }
+
+    private fun String.isRegex() = this.startsWith("re:")
+
+    private fun String.stripRegexPrefix() = this.removePrefix("re:")
+
+    // region Legacy
+    private fun createLegacyAppRoute(primary: FlaisApplication) =
+        Routes().apply {
+            kind = Routes.Kind.RULE
+            match = createLegacyMatch(primary)
+            services =
+                listOf(
+                    Services().apply {
+                        port = IntOrString(primary.spec.port)
+                        name = primary.metadata.name
+                        namespace = primary.metadata.namespace
+                    },
+                )
+            middlewares =
+                primary.spec.ingress?.middlewares?.map {
+                    Middlewares().apply {
+                        name = it
+                        namespace = primary.metadata.namespace
+                    }
+                }
+        }
+
+    private fun createLegacyMatch(primary: FlaisApplication) =
+        listOfNotNull(
+            "Host(`${primary.spec.url.hostname}`)",
+            legacyBasePath(primary).takeUnless { it.isEmpty() }?.let { "PathPrefix(`$it`)" },
+        ).joinToString(" && ")
+
+    private fun legacyBasePath(primary: FlaisApplication) =
+        primary.spec.ingress
+            ?.basePath
+            .takeUnless { it.isNullOrEmpty() }
+            ?: primary.spec.url.basePath
+                .orEmpty()
+
+    override fun shouldReconcile(
+        primary: FlaisApplication,
+        context: Context<FlaisApplication>,
+    ): Boolean {
+        return primary.spec.isIngressEnabled() && config.ingress.traefikV3CrdSupport
+    }
+    // endregion
+}

--- a/src/main/resources/kubernetes/ingressroutes.traefik.io-v1alpha1.yaml
+++ b/src/main/resources/kubernetes/ingressroutes.traefik.io-v1alpha1.yaml
@@ -1,0 +1,285 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    name: ingressroutes.traefik.io
+spec:
+    conversion:
+        strategy: None
+    group: traefik.io
+    names:
+        kind: IngressRoute
+        listKind: IngressRouteList
+        plural: ingressroutes
+        singular: ingressroute
+    scope: Namespaced
+    versions:
+        - name: v1alpha1
+          schema:
+              openAPIV3Schema:
+                  description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
+                  properties:
+                      apiVersion:
+                          description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                      kind:
+                          description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                      metadata:
+                          type: object
+                      spec:
+                          description: IngressRouteSpec defines the desired state of IngressRoute.
+                          properties:
+                              entryPoints:
+                                  description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.10/routing/entrypoints/
+                  Default: all.'
+                                  items:
+                                      type: string
+                                  type: array
+                              routes:
+                                  description: Routes defines the list of routes.
+                                  items:
+                                      description: Route holds the HTTP route configuration.
+                                      properties:
+                                          kind:
+                                              description: Kind defines the kind of the route. Rule is the
+                                                  only supported kind.
+                                              enum:
+                                                  - Rule
+                                              type: string
+                                          match:
+                                              description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#rule'
+                                              type: string
+                                          middlewares:
+                                              description: 'Middlewares defines the list of references to
+                        Middleware resources. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-middleware'
+                                              items:
+                                                  description: MiddlewareRef is a reference to a Middleware
+                                                      resource.
+                                                  properties:
+                                                      name:
+                                                          description: Name defines the name of the referenced Middleware
+                                                              resource.
+                                                          type: string
+                                                      namespace:
+                                                          description: Namespace defines the namespace of the referenced
+                                                              Middleware resource.
+                                                          type: string
+                                                  required:
+                                                      - name
+                                                  type: object
+                                              type: array
+                                          priority:
+                                              description: 'Priority defines the router''s priority. More
+                        info: https://doc.traefik.io/traefik/v2.10/routing/routers/#priority'
+                                              type: integer
+                                          services:
+                                              description: Services defines the list of Service. It can contain
+                                                  any combination of TraefikService and/or reference to a Kubernetes
+                                                  Service.
+                                              items:
+                                                  description: Service defines an upstream HTTP service to proxy
+                                                      traffic to.
+                                                  properties:
+                                                      kind:
+                                                          description: Kind defines the kind of the Service.
+                                                          enum:
+                                                              - Service
+                                                              - TraefikService
+                                                          type: string
+                                                      name:
+                                                          description: Name defines the name of the referenced Kubernetes
+                                                              Service or TraefikService. The differentiation between
+                                                              the two is specified in the Kind field.
+                                                          type: string
+                                                      namespace:
+                                                          description: Namespace defines the namespace of the referenced
+                                                              Kubernetes Service or TraefikService.
+                                                          type: string
+                                                      nativeLB:
+                                                          description: NativeLB controls, when creating the load-balancer,
+                                                              whether the LB's children are directly the pods IPs
+                                                              or if the only child is the Kubernetes Service clusterIP.
+                                                              The Kubernetes Service itself does load-balance to the
+                                                              pods. By default, NativeLB is false.
+                                                          type: boolean
+                                                      passHostHeader:
+                                                          description: PassHostHeader defines whether the client
+                                                              Host header is forwarded to the upstream Kubernetes
+                                                              Service. By default, passHostHeader is true.
+                                                          type: boolean
+                                                      port:
+                                                          anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                          description: Port defines the port of a Kubernetes Service.
+                                                              This can be a reference to a named port.
+                                                          x-kubernetes-int-or-string: true
+                                                      responseForwarding:
+                                                          description: ResponseForwarding defines how Traefik forwards
+                                                              the response from the upstream Kubernetes Service to
+                                                              the client.
+                                                          properties:
+                                                              flushInterval:
+                                                                  description: 'FlushInterval defines the interval,
+                                  in milliseconds, in between flushes to the client
+                                  while copying the response body. A negative value
+                                  means to flush immediately after each write to the
+                                  client. This configuration is ignored when ReverseProxy
+                                  recognizes a response as a streaming response; for
+                                  such responses, writes are flushed to the client
+                                  immediately. Default: 100ms'
+                                                                  type: string
+                                                          type: object
+                                                      scheme:
+                                                          description: Scheme defines the scheme to use for the
+                                                              request to the upstream Kubernetes Service. It defaults
+                                                              to https when Kubernetes Service port is 443, http otherwise.
+                                                          type: string
+                                                      serversTransport:
+                                                          description: ServersTransport defines the name of ServersTransport
+                                                              resource to use. It allows to configure the transport
+                                                              between Traefik and your servers. Can only be used on
+                                                              a Kubernetes Service.
+                                                          type: string
+                                                      sticky:
+                                                          description: 'Sticky defines the sticky sessions configuration.
+                              More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions'
+                                                          properties:
+                                                              cookie:
+                                                                  description: Cookie defines the sticky cookie configuration.
+                                                                  properties:
+                                                                      httpOnly:
+                                                                          description: HTTPOnly defines whether the cookie
+                                                                              can be accessed by client-side APIs, such as
+                                                                              JavaScript.
+                                                                          type: boolean
+                                                                      name:
+                                                                          description: Name defines the Cookie name.
+                                                                          type: string
+                                                                      sameSite:
+                                                                          description: 'SameSite defines the same site policy.
+                                      More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                                                          type: string
+                                                                      secure:
+                                                                          description: Secure defines whether the cookie
+                                                                              can only be transmitted over an encrypted connection
+                                                                              (i.e. HTTPS).
+                                                                          type: boolean
+                                                                  type: object
+                                                          type: object
+                                                      strategy:
+                                                          description: Strategy defines the load balancing strategy
+                                                              between the servers. RoundRobin is the only supported
+                                                              value at the moment.
+                                                          type: string
+                                                      weight:
+                                                          description: Weight defines the weight and should only
+                                                              be specified when Name references a TraefikService object
+                                                              (and to be precise, one that embeds a Weighted Round
+                                                              Robin).
+                                                          type: integer
+                                                  required:
+                                                      - name
+                                                  type: object
+                                              type: array
+                                      required:
+                                          - kind
+                                          - match
+                                      type: object
+                                  type: array
+                              tls:
+                                  description: 'TLS defines the TLS configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#tls'
+                                  properties:
+                                      certResolver:
+                                          description: 'CertResolver defines the name of the certificate
+                      resolver to use. Cert resolvers have to be configured in the
+                      static configuration. More info: https://doc.traefik.io/traefik/v2.10/https/acme/#certificate-resolvers'
+                                          type: string
+                                      domains:
+                                          description: 'Domains defines the list of domains that will be
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#domains'
+                                          items:
+                                              description: Domain holds a domain name with SANs.
+                                              properties:
+                                                  main:
+                                                      description: Main defines the main domain name.
+                                                      type: string
+                                                  sans:
+                                                      description: SANs defines the subject alternative domain
+                                                          names.
+                                                      items:
+                                                          type: string
+                                                      type: array
+                                              type: object
+                                          type: array
+                                      options:
+                                          description: 'Options defines the reference to a TLSOption, that
+                      specifies the parameters of the TLS connection. If not defined,
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#tls-options'
+                                          properties:
+                                              name:
+                                                  description: 'Name defines the name of the referenced TLSOption.
+                          More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsoption'
+                                                  type: string
+                                              namespace:
+                                                  description: 'Namespace defines the namespace of the referenced
+                          TLSOption. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsoption'
+                                                  type: string
+                                          required:
+                                              - name
+                                          type: object
+                                      secretName:
+                                          description: SecretName is the name of the referenced Kubernetes
+                                              Secret to specify the certificate details.
+                                          type: string
+                                      store:
+                                          description: Store defines the reference to the TLSStore, that
+                                              will be used to store certificates. Please note that only `default`
+                                              TLSStore can be used.
+                                          properties:
+                                              name:
+                                                  description: 'Name defines the name of the referenced TLSStore.
+                          More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsstore'
+                                                  type: string
+                                              namespace:
+                                                  description: 'Namespace defines the namespace of the referenced
+                          TLSStore. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsstore'
+                                                  type: string
+                                          required:
+                                              - name
+                                          type: object
+                                  type: object
+                          required:
+                              - routes
+                          type: object
+                  required:
+                      - metadata
+                      - spec
+                  type: object
+          served: true
+          storage: true
+status:
+    acceptedNames:
+        kind: IngressRoute
+        listKind: IngressRouteList
+        plural: ingressroutes
+        singular: ingressroute
+    conditions:
+        - lastTransitionTime: "2023-09-04T12:29:09Z"
+          message: no conflicts found
+          reason: NoConflicts
+          status: "True"
+          type: NamesAccepted
+        - lastTransitionTime: "2023-09-04T12:29:09Z"
+          message: the initial names have been accepted
+          reason: InitialNamesAccepted
+          status: "True"
+          type: Established
+    storedVersions:
+        - v1alpha1

--- a/src/test/integration/kotlin/no/fintlabs/application/IngressV3DRTest.kt
+++ b/src/test/integration/kotlin/no/fintlabs/application/IngressV3DRTest.kt
@@ -1,0 +1,111 @@
+package no.fintlabs.application
+
+import io.traefik.v1alpha1.IngressRoute
+import no.fintlabs.Config
+import no.fintlabs.IngressConfig
+import no.fintlabs.application.Utils.createAndGetResource
+import no.fintlabs.application.Utils.createApplicationKoinTestExtension
+import no.fintlabs.application.Utils.createApplicationKubernetesOperatorExtension
+import no.fintlabs.application.Utils.createTestFlaisApplication
+import no.fintlabs.application.api.v1alpha1.FlaisApplication
+import no.fintlabs.application.api.v1alpha1.Ingress
+import no.fintlabs.extensions.KubernetesOperatorContext
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class IngressV3DRTest {
+    @Test
+    fun `should create simple IngressRoute`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec =
+                    spec.copy(
+                        ingress = Ingress(routes = listOf(Ingress.Route("test.example.com", "/test"))),
+                    )
+            }
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNotNull(ingressRoute)
+        assertEquals("test", ingressRoute.metadata.name)
+        assertEquals("web", ingressRoute.spec.entryPoints[0])
+        assertEquals(
+            "Host(`test.example.com`) && PathPrefix(`/test`)",
+            ingressRoute.spec.routes[0].match,
+        )
+        assertEquals(
+            8080,
+            ingressRoute.spec.routes[0]
+                .services[0]
+                .port.intVal,
+        )
+        assertEquals(
+            "test",
+            ingressRoute.spec.routes[0]
+                .services[0]
+                .name,
+        )
+        assertEquals(
+            context.namespace,
+            ingressRoute.spec.routes[0]
+                .services[0]
+                .namespace,
+        )
+    }
+
+    @Test
+    fun `should create IngressRoute with regex header`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec =
+                    spec.copy(
+                        ingress =
+                            Ingress(
+                                routes =
+                                    listOf(
+                                        Ingress.Route(
+                                            host = "test.example.com",
+                                            path = "/test",
+                                            headers = mapOf("header" to "re:value.*"),
+                                        ),
+                                    ),
+                            ),
+                    )
+            }
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNotNull(ingressRoute)
+        assertEquals(
+            "Host(`test.example.com`) && PathPrefix(`/test`) && HeadersRegexp(`header`, `value.*`)",
+            ingressRoute.spec.routes[0].match,
+        )
+    }
+
+    @Test
+    fun `should not create IngressRoute`(context: KubernetesOperatorContext) {
+        val flaisApplication = createTestFlaisApplication()
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNull(ingressRoute)
+    }
+
+    private fun KubernetesOperatorContext.createAndGetIngressRoute(app: FlaisApplication) = createAndGetResource<IngressRoute>(app)
+
+    companion object {
+        @RegisterExtension
+        val koinTestExtension =
+            createApplicationKoinTestExtension(
+                module {
+                    single {
+                        Config(ingress = IngressConfig(traefikV3CrdSupport = true))
+                    }
+                },
+            )
+
+        @RegisterExtension
+        val kubernetesOperatorExtension = createApplicationKubernetesOperatorExtension()
+    }
+}

--- a/src/test/integration/kotlin/no/fintlabs/application/IngressV3LegacyDRTest.kt
+++ b/src/test/integration/kotlin/no/fintlabs/application/IngressV3LegacyDRTest.kt
@@ -1,0 +1,169 @@
+package no.fintlabs.application
+
+import io.fabric8.kubernetes.client.KubernetesClientException
+import io.traefik.v1alpha1.IngressRoute
+import no.fintlabs.Config
+import no.fintlabs.IngressConfig
+import no.fintlabs.application.Utils.createAndGetResource
+import no.fintlabs.application.Utils.createApplicationKoinTestExtension
+import no.fintlabs.application.Utils.createApplicationKubernetesOperatorExtension
+import no.fintlabs.application.Utils.createTestFlaisApplication
+import no.fintlabs.application.api.v1alpha1.FlaisApplication
+import no.fintlabs.application.api.v1alpha1.Ingress
+import no.fintlabs.application.api.v1alpha1.Url
+import no.fintlabs.extensions.KubernetesOperatorContext
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Tags
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class IngressV3LegacyDRTest {
+    // region General
+    @Test
+    @Tags(Tag("legacy-ingress"))
+    fun `should create IngressRoute`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec = spec.copy(url = Url("test.example.com", "/test"), ingress = Ingress(true))
+            }
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNotNull(ingressRoute)
+        assertEquals("test", ingressRoute.metadata.name)
+        assertEquals("web", ingressRoute.spec.entryPoints[0])
+        assertEquals(
+            "Host(`test.example.com`) && PathPrefix(`/test`)",
+            ingressRoute.spec.routes[0].match,
+        )
+        assertEquals(
+            8080,
+            ingressRoute.spec.routes[0]
+                .services[0]
+                .port.intVal,
+        )
+        assertEquals(
+            "test",
+            ingressRoute.spec.routes[0]
+                .services[0]
+                .name,
+        )
+        assertEquals(
+            context.namespace,
+            ingressRoute.spec.routes[0]
+                .services[0]
+                .namespace,
+        )
+    }
+
+    @Test
+    fun `should not create IngressRoute since enabled is false`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec = spec.copy(url = Url("test.example.com", "/test"), ingress = Ingress(false))
+            }
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNull(ingressRoute)
+    }
+
+    @Test
+    fun `should not create IngressRoute since url is not set`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply { spec = spec.copy(ingress = Ingress(true)) }
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNull(ingressRoute)
+    }
+
+    // endregion
+
+    // region Rules
+    @Test
+    fun `should not accept invalid hostname`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec = spec.copy(url = Url("notAValidHostname/&%", "/test"), ingress = Ingress(true))
+            }
+
+        try {
+            context.create(flaisApplication)
+        } catch (e: KubernetesClientException) {
+            assertEquals(422, e.code)
+            assertEquals("Invalid", e.status.reason)
+            assert(e.status.message.contains("Invalid hostname"))
+        }
+    }
+
+    @Test
+    fun `should not accept invalid path`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec =
+                    spec.copy(
+                        url = Url("test.example.com", "notAValidPath/&%=##dfnjkdkjn44"),
+                        ingress = Ingress(true),
+                    )
+            }
+
+        try {
+            context.create(flaisApplication)
+        } catch (e: KubernetesClientException) {
+            assertEquals(422, e.code)
+            assertEquals("Invalid", e.status.reason)
+            assert(e.status.message.contains("Invalid path"))
+        }
+    }
+
+    // endregion
+
+    // region RouteMatch
+    @Test
+    fun `should create IngressRoute with default path`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec = spec.copy(url = Url("test.example.com"), ingress = Ingress(true))
+            }
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNotNull(ingressRoute)
+        assertEquals("Host(`test.example.com`)", ingressRoute.spec.routes[0].match)
+    }
+
+    @Test
+    fun `should create IngressRoute with custom path`(context: KubernetesOperatorContext) {
+        val flaisApplication =
+            createTestFlaisApplication().apply {
+                spec = spec.copy(url = Url("test.example.com", "/test"), ingress = Ingress(true))
+            }
+
+        val ingressRoute = context.createAndGetIngressRoute(flaisApplication)
+        assertNotNull(ingressRoute)
+        assertEquals(
+            "Host(`test.example.com`) && PathPrefix(`/test`)",
+            ingressRoute.spec.routes[0].match,
+        )
+    }
+
+    // endregion
+
+    private fun KubernetesOperatorContext.createAndGetIngressRoute(app: FlaisApplication) = createAndGetResource<IngressRoute>(app)
+
+    companion object {
+        @RegisterExtension
+        val koinTestExtension =
+            createApplicationKoinTestExtension(
+                module {
+                    single {
+                        Config(ingress = IngressConfig(traefikV3CrdSupport = true))
+                    }
+                },
+            )
+
+        @RegisterExtension
+        val kubernetesOperatorExtension = createApplicationKubernetesOperatorExtension()
+    }
+}

--- a/src/test/integration/kotlin/no/fintlabs/application/Utils.kt
+++ b/src/test/integration/kotlin/no/fintlabs/application/Utils.kt
@@ -14,6 +14,7 @@ import no.fintlabs.v1alpha1.KafkaUserAndAcl
 import no.fintlabs.v1alpha1.PGUser
 import org.koin.core.module.Module
 import us.containo.traefik.v1alpha1.IngressRoute
+import io.traefik.v1alpha1.IngressRoute as IngressRouteV3
 
 object Utils {
     fun createTestFlaisApplication(): FlaisApplication {
@@ -45,6 +46,7 @@ object Utils {
             listOf(
                 FlaisApplication::class.java,
                 IngressRoute::class.java,
+                IngressRouteV3::class.java,
                 PGUser::class.java,
                 KafkaUserAndAcl::class.java,
                 OnePasswordItem::class.java,


### PR DESCRIPTION
## Summary
- add Traefik v3 IngressV3DR dependent resource and bundle the Traefik v3 IngressRoute CRD manifest
- wire Traefik v3 ingress reconciliation into the application reconciler and module registration
- extend integration test setup to include v3 IngressRoute resources
- add integration tests for route-based and legacy ingress behavior with Traefik v3

## Notes
- legacy ingress tests are included in IngressV3LegacyDRTest
- v3 route-style tests are included in IngressV3DRTest